### PR TITLE
feat: 코드블럭 dracula 테마 적용

### DIFF
--- a/css/prism.css
+++ b/css/prism.css
@@ -7,37 +7,37 @@
 
 /* Code title styles */
 .remark-code-title {
-  @apply rounded-t bg-gray-700 px-5 py-3 font-mono text-sm font-bold text-gray-200;
+    @apply rounded-t bg-gray-700 px-5 py-3 font-mono text-sm font-bold text-gray-200;
 }
 
 .remark-code-title + div > pre {
-  @apply mt-0 rounded-t-none;
+    @apply mt-0 rounded-t-none;
 }
 
 /* Code block styles */
 .code-highlight {
-  @apply float-left min-w-full;
+    @apply float-left min-w-full;
 }
 
 .code-line {
-  @apply -mx-4 block border-l-4 border-transparent pl-4 pr-4;
+    @apply -mx-4 block border-l-4 border-transparent pl-4 pr-4;
 }
 
 .code-line.inserted {
-  @apply bg-green-500 bg-opacity-20;
+    @apply bg-green-500 bg-opacity-20;
 }
 
 .code-line.deleted {
-  @apply bg-red-500 bg-opacity-20;
+    @apply bg-red-500 bg-opacity-20;
 }
 
 .highlight-line {
-  @apply -mx-4 border-l-4 border-primary-500 bg-gray-700 bg-opacity-50;
+    @apply -mx-4 border-l-4 border-primary-500 bg-gray-700 bg-opacity-50;
 }
 
 .line-number::before {
-  @apply mr-4 -ml-2 inline-block w-4 text-right text-gray-400;
-  content: attr(line);
+    @apply mr-4 -ml-2 inline-block w-4 text-right text-gray-400;
+    content: attr(line);
 }
 
 /* Token styles */
@@ -48,97 +48,181 @@
  * Ported by Sara vieria [@SaraVieira]
  * Added by Souvik Mandal [@SimpleIndian]
  */
-.token.comment,
-.token.prolog,
-.token.cdata {
-  color: rgb(99, 119, 119);
-  font-style: italic;
+
+:root {
+    --background: #282A36;
+    --comment: #6272A4; /* use */
+    --foreground: #F8F8F2; /* use */
+    --selection: #44475A;
+    --cyan: #8BE9FD; /* use */
+    --green: #50FA7B; /* use */
+    --orange: #FFB86C; /* use */
+    --pink: #FF79C6; /* use */
+    --purple: #BD93F9; /* use */
+    --red: #FF5555; /* use */
+    --yellow: #F1FA8C; /* use */
+    --background-30: #282A3633;
+    --comment-30: #6272A433;
+    --foreground-30: #F8F8F233;
+    --selection-30: #44475A33;
+    --cyan-30: #8BE9FD33;
+    --green-30: #50FA7B33;
+    --orange-30: #FFB86C33;
+    --pink-30: #FF79C633;
+    --purple-30: #BD93F933;
+    --red-30: #FF555533;
+    --yellow-30: #F1FA8C33;
+    --background-40: #282A3666;
+    --comment-40: #6272A466;
+    --foreground-40: #F8F8F266;
+    --selection-40: #44475A66;
+    --cyan-40: #8BE9FD66;
+    --green-40: #50FA7B66;
+    --orange-40: #FFB86C66;
+    --pink-40: #FF79C666;
+    --purple-40: #BD93F966;
+    --red-40: #FF555566;
+    --yellow-40: #F1FA8C66
 }
 
-.token.punctuation {
-  color: rgb(199, 146, 234);
+.limit-300 {
+    height: 300px !important
+}
+
+.limit-300 {
+    height: 400px !important
+}
+
+.limit-500 {
+    height: 500px !important
+}
+
+.limit-600 {
+    height: 600px !important
+}
+
+.limit-700 {
+    height: 700px !important
+}
+
+.limit-800 {
+    height: 800px !important
+}
+
+.token.comment,
+.token.variable
+{
+    color: var(--comment);
+}
+
+.token.prolog {
+    color: var(--foreground);
+}
+
+/*
+.token.cdata {
+    color: rgb(99, 119, 119);
+    font-style: italic;
+}
+*/
+
+.token.punctuation,
+.token.property
+{
+    color: var(--orange);
 }
 
 .namespace {
-  color: rgb(178, 204, 214);
+    color: #e2777a;
 }
 
-.token.deleted {
-  color: rgba(239, 83, 80, 0.56);
-  font-style: italic;
-}
-
-.token.symbol,
-.token.property {
-  color: rgb(128, 203, 196);
+.token.symbol {
+    color: rgba(255, 184, 108, 1);
 }
 
 .token.tag,
-.token.operator,
-.token.keyword {
-  color: rgb(127, 219, 202);
+.token.keyword,
+.token.selector,
+.token.entity,
+.token.important
+{
+    color: var(--pink);
 }
 
-.token.boolean {
-  color: rgb(255, 88, 116);
+.token.operator {
+    color: rgba(139, 233, 253, 1);
+}
+
+.token.boolean,
+.token.constant
+{
+    color: var(--purple);
 }
 
 .token.number {
-  color: rgb(247, 140, 108);
+    color: rgba(189, 147, 249, 1);
 }
 
-.token.constant,
 .token.function,
-.token.builtin,
-.token.char {
-  color: rgb(130, 170, 255);
-}
-
-.token.selector,
-.token.doctype {
-  color: rgb(199, 146, 234);
-  font-style: italic;
-}
-
 .token.attr-name,
-.token.inserted {
-  color: rgb(173, 219, 103);
-  font-style: italic;
-}
-
-.token.string,
-.token.url,
-.token.entity,
-.language-css .token.string,
-.style .token.string {
-  color: rgb(173, 219, 103);
-}
-
-.token.class-name,
 .token.atrule,
-.token.attr-value {
-  color: rgb(255, 203, 139);
+.token.attr-value
+{
+    color: var(--green);
 }
 
-.token.regex,
-.token.important,
-.token.variable {
-  color: rgb(214, 222, 235);
+.token.builtin,
+.token.url,
+.token.class-name
+{
+    color: var(--cyan);
+}
+
+.language-css .token.url {
+    color: var(--orange)
+}
+
+.token.char {
+    color: rgba(255, 135, 157, 1);
+}
+
+/*
+.token.doctype {
+    color: rgb(199, 146, 234);
+    font-style: italic;
+}
+*/
+
+/*
+.token.inserted {
+    color: rgb(173, 219, 103);
+    font-style: italic;
+}
+*/
+
+.token.string {
+    color: var(--yellow);
+}
+
+.token.regex {
+    color: var(--red);
 }
 
 .token.important,
 .token.bold {
-  font-weight: bold;
+    font-weight: bold;
 }
 
 .token.italic {
-  font-style: italic;
+    font-style: italic;
 }
 
 .token.table {
-  display: inline;
+    display: inline;
 }
 
 .token.table {
-  display: inline;
+    display: inline;
 }
+
+/**************/

--- a/css/prism.css
+++ b/css/prism.css
@@ -1,13 +1,6 @@
-/**
- * CSS Styles for code highlighting.
- * Feel free to customize token styles 
- * by copying from a prismjs compatible theme:
- * https://github.com/PrismJS/prism-themes
- */
-
 /* Code title styles */
 .remark-code-title {
-    @apply rounded-t bg-gray-700 px-5 py-3 font-mono text-sm font-bold text-gray-200;
+    @apply rounded-t bg-gray-700 px-5 py-3 font-mono text-base font-bold text-gray-200;
 }
 
 .remark-code-title + div > pre {
@@ -24,33 +17,43 @@
 }
 
 .code-line.inserted {
-    @apply bg-green-500 bg-opacity-20;
+    background-color: var(--green-30);
 }
 
 .code-line.deleted {
-    @apply bg-red-500 bg-opacity-20;
+    background-color: var(--red-30);
 }
 
 .highlight-line {
-    @apply -mx-4 border-l-4 border-primary-500 bg-gray-700 bg-opacity-50;
+    color: var(--foreground);
+    background-color: var(--comment-30);
+    @apply -mx-4 border-l-4 border-primary-500;
 }
 
 .line-number::before {
-    @apply mr-4 -ml-2 inline-block w-4 text-right text-gray-400;
     content: attr(line);
+    @apply mr-4 -ml-2 inline-block w-4 text-right text-gray-400;
 }
 
 :root {
-    --background: #282A36;
-    --comment: #6272A4; /* use */
-    --foreground: #F8F8F2; /* use */
-    --cyan: #8BE9FD; /* use */
-    --green: #50FA7B; /* use */
-    --orange: #FFB86C; /* use */
-    --pink: #FF79C6; /* use */
-    --purple: #BD93F9; /* use */
-    --red: #FF5555; /* use */
-    --yellow: #F1FA8C; /* use */
+    --selection: #44475A;
+    --comment: #6272A4;
+    --foreground: #F8F8F2;
+    --cyan: #8BE9FD;
+    --green: #50FA7B;
+    --orange: #FFB86C;
+    --pink: #FF79C6;
+    --purple: #BD93F9;
+    --red: #FF5555;
+    --yellow: #F1FA8C;
+
+    --comment-30: #6272A433;
+    --green-30: #50FA7B33;
+    --red-30: #FF555533;
+}
+
+pre > code {
+    background-color: inherit !important;
 }
 
 pre::-webkit-scrollbar {
@@ -66,32 +69,22 @@ pre::-webkit-scrollbar-thumb {
     border-radius: 8px;
 }
 
-.limit-300 {
-    height: 300px !important
+code[class*=language-] ::-moz-selection, code[class*=language-]::-moz-selection, pre[class*=language-] ::-moz-selection, pre[class*=language-]::-moz-selection {
+    text-shadow: none;
+    background-color: var(--selection)
 }
 
-.limit-300 {
-    height: 400px !important
-}
-
-.limit-500 {
-    height: 500px !important
-}
-
-.limit-600 {
-    height: 600px !important
-}
-
-.limit-700 {
-    height: 700px !important
-}
-
-.limit-800 {
-    height: 800px !important
+code[class*=language-] ::selection, code[class*=language-]::selection, pre[class*=language-] ::selection, pre[class*=language-]::selection {
+    text-shadow: none;
+    background-color: var(--selection)
 }
 
 .language-css {
-    color: var(--purple)
+    color: var(--purple);
+}
+
+.language-css .token {
+    color: var(--pink);
 }
 
 .token.comment,
@@ -100,12 +93,15 @@ pre::-webkit-scrollbar-thumb {
     color: var(--comment);
 }
 
-.token.prolog {
+.token.prolog,
+.token.spread
+{
     color: var(--foreground);
 }
 
 .token.punctuation,
-.token.property
+.token.property,
+.token.property-access
 {
     color: var(--orange);
 }
@@ -132,7 +128,9 @@ pre::-webkit-scrollbar-thumb {
 }
 
 .token.boolean,
-.token.constant
+.token.constant,
+.token.unit,
+.token.hexcode
 {
     color: var(--purple);
 }
@@ -150,13 +148,20 @@ pre::-webkit-scrollbar-thumb {
 
 .token.builtin,
 .token.url,
-.token.class-name
+.token.class-name,
+.token.class
 {
     color: var(--cyan);
 }
+
+.token.console {
+    color: var(--purple);
+}
+
 .token.attr-value,
 .language-css .token.url,
-.token.string
+.token.string,
+.token.regex
 {
     color: var(--yellow);
 }
@@ -165,8 +170,15 @@ pre::-webkit-scrollbar-thumb {
     color: rgba(255, 135, 157, 1);
 }
 
-.token.regex {
-    color: var(--red);
+
+.token.arrow,
+.token.script {
+    color: var(--foreground);
+}
+
+.token.regex-delimiter,
+.token.regex-flags {
+    color: #6897bb;
 }
 
 .token.important,
@@ -185,6 +197,3 @@ pre::-webkit-scrollbar-thumb {
 .token.table {
     display: inline;
 }
-
-
-/**************/

--- a/css/prism.css
+++ b/css/prism.css
@@ -40,20 +40,10 @@
     content: attr(line);
 }
 
-/* Token styles */
-/**
- * MIT License
- * Copyright (c) 2018 Sarah Drasner
- * Sarah Drasner's[@sdras] Night Owl
- * Ported by Sara vieria [@SaraVieira]
- * Added by Souvik Mandal [@SimpleIndian]
- */
-
 :root {
     --background: #282A36;
     --comment: #6272A4; /* use */
     --foreground: #F8F8F2; /* use */
-    --selection: #44475A;
     --cyan: #8BE9FD; /* use */
     --green: #50FA7B; /* use */
     --orange: #FFB86C; /* use */
@@ -61,28 +51,19 @@
     --purple: #BD93F9; /* use */
     --red: #FF5555; /* use */
     --yellow: #F1FA8C; /* use */
-    --background-30: #282A3633;
-    --comment-30: #6272A433;
-    --foreground-30: #F8F8F233;
-    --selection-30: #44475A33;
-    --cyan-30: #8BE9FD33;
-    --green-30: #50FA7B33;
-    --orange-30: #FFB86C33;
-    --pink-30: #FF79C633;
-    --purple-30: #BD93F933;
-    --red-30: #FF555533;
-    --yellow-30: #F1FA8C33;
-    --background-40: #282A3666;
-    --comment-40: #6272A466;
-    --foreground-40: #F8F8F266;
-    --selection-40: #44475A66;
-    --cyan-40: #8BE9FD66;
-    --green-40: #50FA7B66;
-    --orange-40: #FFB86C66;
-    --pink-40: #FF79C666;
-    --purple-40: #BD93F966;
-    --red-40: #FF555566;
-    --yellow-40: #F1FA8C66
+}
+
+pre::-webkit-scrollbar {
+    @apply h-3;
+}
+
+pre::-webkit-scrollbar-track {
+    background-color: var(--comment);
+}
+
+pre::-webkit-scrollbar-thumb {
+    background-color: var(--purple);
+    border-radius: 8px;
 }
 
 .limit-300 {
@@ -109,6 +90,10 @@
     height: 800px !important
 }
 
+.language-css {
+    color: var(--purple)
+}
+
 .token.comment,
 .token.variable
 {
@@ -118,13 +103,6 @@
 .token.prolog {
     color: var(--foreground);
 }
-
-/*
-.token.cdata {
-    color: rgb(99, 119, 119);
-    font-style: italic;
-}
-*/
 
 .token.punctuation,
 .token.property
@@ -140,10 +118,10 @@
     color: rgba(255, 184, 108, 1);
 }
 
+.token.entity,
 .token.tag,
 .token.keyword,
 .token.selector,
-.token.entity,
 .token.important
 {
     color: var(--pink);
@@ -165,8 +143,7 @@
 
 .token.function,
 .token.attr-name,
-.token.atrule,
-.token.attr-value
+.token.atrule
 {
     color: var(--green);
 }
@@ -177,31 +154,15 @@
 {
     color: var(--cyan);
 }
-
-.language-css .token.url {
-    color: var(--orange)
+.token.attr-value,
+.language-css .token.url,
+.token.string
+{
+    color: var(--yellow);
 }
 
 .token.char {
     color: rgba(255, 135, 157, 1);
-}
-
-/*
-.token.doctype {
-    color: rgb(199, 146, 234);
-    font-style: italic;
-}
-*/
-
-/*
-.token.inserted {
-    color: rgb(173, 219, 103);
-    font-style: italic;
-}
-*/
-
-.token.string {
-    color: var(--yellow);
 }
 
 .token.regex {
@@ -224,5 +185,6 @@
 .token.table {
     display: inline;
 }
+
 
 /**************/

--- a/data/blog/new-features-in-v1.mdx
+++ b/data/blog/new-features-in-v1.mdx
@@ -25,7 +25,13 @@ See [upgrade guide](#upgrade-guide) below if you are migrating from v0 version o
 
 You can easily modify the theme color by changing the primary attribute in the tailwind config file:
 
+```python:hello.py
+a = int(input('날씨가 몹시 덥네요'))
+print(a)
+```
+
 ```js:tailwind.config.js
+const children = 10;
 theme: {
     colors: {
       primary: colors.teal,
@@ -60,8 +66,8 @@ Some new possibilities include loading components directly in the mdx file using
 For example, the following jsx snippet can be used directly in an MDX file to render the page title component:
 
 ```jsx
-import PageTitle from './components/PageTitle.tsx'
-;<PageTitle> Using JSX components in MDX </PageTitle>
+import PageTitle from './components/PageTitle.tsx';
+<PageTitle> Using JSX components in MDX </PageTitle>
 ```
 
 import PageTitle from './components/PageTitle.tsx'
@@ -299,10 +305,49 @@ The following javascript code block:
 var num1, num2, sum
 - const a = 10;
 const a = 20;
-num1 = prompt('Enter first number')
++ num1 = prompt('Enter first number')
 num2 = prompt('Enter second number')
 - sum = parseInt(num1) + parseInt(num2) // "+" means "add"
 alert('Sum = ' + sum) // "+" means combine into a string
+const bool = 1 <= 2;
+```
+
+```html {1,3,4,5,6}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" href="https://unpkg.com/dracula-prism/dist/css/dracula-prism.min.css"/>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>
+```
+
+```css
+@import url('https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.2/katex.min.css');
+
+@media screen and (min-width: 768px) { /* ... */ }
+
+```
+
+```tsx showLineNumbers
+import Link from 'next/link';
+
+export default function Slider() {
+  const name = 'jintak0401';
+  const tmp = {name: '진탁', nickname: '바보'};
+  const re = /ab+c/gi;
+  return <div>
+    <button onClick={() => console.log(1 < 2 ? tmp.name: tmp.nickname)}>버튼</button>
+    <span>진탁</span>
+    <Link href={`https://github.com/${name}`}>
+      <a>깃 허브로 바로가기</a>
+    </Link>
+  </div>;
+}
 ```
 
 will appear as:
@@ -318,6 +363,14 @@ alert('Sum = ' + sum) // "+" means combine into a string
 To modify the styles, change the following class selectors in the `prism.css` file:
 
 ```css
+
+html {
+  color: #111111;
+  padding: 6px;
+  display: flex;
+  flex-direction: row;
+}
+
 .code-highlight {
   @apply float-left min-w-full;
 }
@@ -404,11 +457,7 @@ See [rehype-citation readme](https://github.com/timlrx/rehype-citation) for more
 
 Google font has been replaced with self-hosted font from [Fontsource](https://fontsource.org/). This gives the following [advantages](https://fontsource.org/docs/introduction):
 
-> Self-hosting brings significant performance gains as loading fonts from hosted services, such as Google Fonts, lead to an extra (render blocking) network request. To provide perspective, for simple websites it has been seen to double visual load times.
->
-> Fonts remain version locked. Google often pushes updates to their fonts without notice, which may interfere with your live production projects. Manage your fonts like any other NPM dependency.
->
-> Commit to privacy. Google does track the usage of their fonts and for those who are extremely privacy concerned, self-hosting is an alternative.
+> Self-hosting brings significant performance gains as loading fonts from hosted services, such as Google Fonts, lead to an extra (render blocking) network request. To provide perspective, for simple websites it has been seen to double visual load times.Fonts remain version locked. Google often pushes updates to their fonts without notice, which may interfere with your live production projects. Manage your fonts like any other NPM dependency.Commit to privacy. Google does track the usage of their fonts and for those who are extremely privacy concerned, self-hosting is an alternative.
 
 This leads to a smaller font bundle and a 0.1s faster load time ([webpagetest comparison](https://www.webpagetest.org/video/compare.php?tests=220201_AiDcFH_f68a69b758454dd52d8e67493fdef7da,220201_BiDcMC_bf2d53f14483814ba61e794311dfa771)).
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -64,7 +64,7 @@ module.exports = {
               color: theme('colors.gray.900'),
             },
             pre: {
-              backgroundColor: theme('colors.gray.800'),
+              backgroundColor: '#282A36',
             },
             code: {
               color: theme('colors.pink.500'),
@@ -132,7 +132,7 @@ module.exports = {
               color: theme('colors.gray.100'),
             },
             pre: {
-              backgroundColor: theme('colors.gray.800'),
+              backgroundColor: '#282A36',
             },
             code: {
               backgroundColor: theme('colors.gray.800'),


### PR DESCRIPTION
* Closes #21 

## ✨ 구현 기능 명세
코드블럭에 dracula 테마를 적용시켰습니다.

## 🎁 PR Point
다른 언어보다는 javascript 위주로 테마를 적용하였습니다. prismjs의 한계로 IDE에서 만큼 디테일하게 적용하지는 못했으나 최대한 비슷하게 적용하였습니다.

## 😭 어려웠던 점
[dracula 테마 prism 페이지](https://draculatheme.com/prism)에서 제공해주는 그대로 적용하니 많이 이상했습니다. 그래서 어떤 선택자들이 어떤 요소의 색상을 결정해주는지 알아가며 하나하나 수정하였습니다. [prism 공식 문서](https://prismjs.com/tokens.html)에 나와있는 것도 참고했으나 이 내용만으로는 디테일하게 색상을 결정할 수 없어서 개발자 도구를 이용해 각 토큰의 클래스 이름들을 알아내가며 색상을 설정해주었습니다.

아무리 해도 DejaVu Sans Mono NF 폰트가 적용되지 않았습니다. woff와 woff2를 직접 호스팅해도 안되며, fontsource 라이브러리를 이용하여도 적용되지 않았습니다. 추후에 새 이슈로 등록하고 적용할 예정입니다.

## ⏰ 실제 소요 시간
5h 30m

## 🖥 스크린샷
![image](https://user-images.githubusercontent.com/32933980/195984819-6abd73ca-d002-4bd6-8595-ed3e0282bad0.png)

