### PR TITLE
feat: 코드 블럭을 제외한 드래그 색상 변경

### DIFF
--- a/css/prism.css
+++ b/css/prism.css
@@ -75,12 +75,14 @@ pre::-webkit-scrollbar-thumb {
 
 code[class*=language-] ::-moz-selection, code[class*=language-]::-moz-selection, pre[class*=language-] ::-moz-selection, pre[class*=language-]::-moz-selection {
     text-shadow: none;
-    background-color: var(--selection)
+    background-color: var(--selection);
+    color: inherit;
 }
 
 code[class*=language-] ::selection, code[class*=language-]::selection, pre[class*=language-] ::selection, pre[class*=language-]::selection {
     text-shadow: none;
-    background-color: var(--selection)
+    background-color: var(--selection);
+    color: inherit;
 }
 
 .language-css {

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -34,6 +34,15 @@ input:-webkit-autofill:focus {
     html {
         font-family: "Pretendard", sans-serif;
     }
+
+    ::selection
+    {
+        @apply bg-primary-100 text-primary-500 dark:bg-primary-800 dark:text-primary-200;
+    }
+
+    ::-moz-selection {
+        @apply bg-primary-100 text-primary-500;
+    }
 }
 
 @layer components {
@@ -88,3 +97,4 @@ body {
     transition: background-color 500ms;
     transition-timing-function: var(--timing-func);
 }
+


### PR DESCRIPTION
* Closes #25 

## ✨ 구현 기능 명세
코드 블럭을 제외한 텍스트를 드래그 했을 때 색상을 primary 색상이 되도록 수정했습니다.

## 🎁 PR Point
코드블럭의 색상은 그대로 유지되도록 코드블럭에 대해서는 `color: inherit`를 추가했습니다.

## 😭 어려웠던 점
코드블럭을 제외하도록 하는 점이 어려웠습니다. 코드블럭 선택자에 `color: inherit`를 추가하면 가능한 것을 `::selection` 선택자에 `:not(code)`나 `:not(.code-line)` 과 같은 선택자를 추가하는 방식으로 해결하려고 했어서 시간을 오래 소모됐습니다. 

## ⏰ 실제 소요 시간
1h

## 🖥 스크린샷

### 라이트모드
![image](https://user-images.githubusercontent.com/32933980/196016553-9f638245-e819-427c-91e5-0fc7b26c6a9b.png)

### 다크모드
![image](https://user-images.githubusercontent.com/32933980/196016718-fb9fe842-516e-416d-af41-4a0f24660321.png)

