### PR TITLE
feat: 사이드 TOC 컴포넌트 추가

### DIFF
--- a/components/TOC.tsx
+++ b/components/TOC.tsx
@@ -4,8 +4,8 @@ const TOC = () => {
   const { headingEls, currentId } = useIntersectionObserver();
 
   return (
-    <aside className="absolute left-full">
-      <ul className="fixed top-56 ml-10 hidden space-y-1.5 self-start 2xl:inline-block">
+    <aside className="absolute left-full ">
+      <ul className="fixed top-56 ml-12 hidden space-y-1.5 self-start border-l-2 pl-5 2xl:inline-block">
         {headingEls
           .filter(({ textContent }) => textContent !== 'Footnotes')
           .map(({ id, textContent, nodeName }) => (

--- a/components/TOC.tsx
+++ b/components/TOC.tsx
@@ -1,10 +1,33 @@
-import { useState } from 'react';
-
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
 
-export default function TOC() {
-  const [currentId, setCurrentId] = useState<string>('');
-  useIntersectionObserver(setCurrentId);
+const TOC = () => {
+  const { headingEls, currentId } = useIntersectionObserver();
 
-  return <div />;
-}
+  return (
+    <aside className="absolute left-full">
+      <ul className="fixed top-56 ml-10 hidden space-y-1.5 self-start 2xl:inline-block">
+        {headingEls
+          .filter(({ textContent }) => textContent !== 'Footnotes')
+          .map(({ id, textContent, nodeName }) => (
+            <li key={id}>
+              <a
+                href={`#${id}`}
+                className={`inline-block transition-colors transition-transform hover:underline
+                ${
+                  currentId === id
+                    ? 'scale-105 text-primary-500 hover:text-primary-600 hover:dark:text-primary-400'
+                    : 'text-gray-500 hover:text-gray-900 hover:dark:text-gray-200'
+                }
+                ${nodeName === 'H3' && 'pl-4'}
+                `}
+              >
+                {textContent}
+              </a>
+            </li>
+          ))}
+      </ul>
+    </aside>
+  );
+};
+
+export default TOC;

--- a/components/TOC.tsx
+++ b/components/TOC.tsx
@@ -4,15 +4,15 @@ const TOC = () => {
   const { headingEls, currentId } = useIntersectionObserver();
 
   return (
-    <aside className="absolute left-full ">
-      <ul className="fixed top-56 ml-12 hidden space-y-1.5 self-start border-l-2 pl-5 2xl:inline-block">
+    <aside className="absolute top-0 left-full hidden h-full break-words 2xl:inline-block">
+      <ul className="sticky top-10 ml-12 w-[calc(49vw-555px)] space-y-1.5 border-l-2 pl-5 transition-colors dark:border-gray-700">
         {headingEls
           .filter(({ textContent }) => textContent !== 'Footnotes')
           .map(({ id, textContent, nodeName }) => (
             <li key={id}>
               <a
                 href={`#${id}`}
-                className={`inline-block transition-colors transition-transform hover:underline
+                className={`inline-block transition-all hover:underline
                 ${
                   currentId === id
                     ? 'scale-105 text-primary-500 hover:text-primary-600 hover:dark:text-primary-400'

--- a/hooks/useIntersectionObserver.ts
+++ b/hooks/useIntersectionObserver.ts
@@ -1,13 +1,15 @@
-import { Dispatch, SetStateAction, useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+import { TocElement } from '@/lib/types';
 
 const observerOption = {
   threshold: 0.4,
   rootMargin: '-90px 0px 0px 0px',
 };
 
-export const useIntersectionObserver = (
-  setId: Dispatch<SetStateAction<string>>
-) => {
+export const useIntersectionObserver = () => {
+  const [currentId, setCurrentId] = useState<string>('');
+  const [headingEls, setHeadingEls] = useState<TocElement[]>([]);
   const dirRef = useRef<string>('');
   const prevYpos = useRef<number>(0);
 
@@ -26,14 +28,22 @@ export const useIntersectionObserver = (
           (dirRef.current === 'down' && !entry.isIntersecting) ||
           (dirRef.current === 'up' && entry.isIntersecting)
         ) {
-          setId(entry.target.id);
+          setCurrentId(entry.target.id);
         }
       });
     }, observerOption);
 
-    const headingEls = document.querySelectorAll('h2, h3');
-    headingEls.forEach((h) => observer.observe(h));
-
+    const els = document.querySelectorAll('h2, h3');
+    setHeadingEls(
+      Array.from(els).map(({ id, nodeName, textContent }) => ({
+        id,
+        nodeName,
+        textContent: textContent as string,
+      }))
+    );
+    els.forEach((h) => observer.observe(h));
     return () => observer.disconnect();
-  }, [setId]);
+  }, []);
+
+  return { currentId, headingEls };
 };

--- a/layouts/PostSimple.tsx
+++ b/layouts/PostSimple.tsx
@@ -51,7 +51,7 @@ export default function PostLayout({ content, next, prev, children }: Props) {
             className="divide-y divide-gray-200 pb-8 dark:divide-gray-700 xl:divide-y-0 "
             style={{ gridTemplateRows: 'auto 1fr' }}
           >
-            <div className="relative divide-y divide-gray-200 dark:divide-gray-700 xl:col-span-3 xl:row-span-2 xl:pb-0">
+            <div className="relative divide-gray-200 dark:divide-gray-700 xl:col-span-3 xl:row-span-2 xl:pb-0">
               <div className="prose max-w-none pt-10 pb-8 dark:prose-dark">
                 {children}
               </div>

--- a/layouts/PostSimple.tsx
+++ b/layouts/PostSimple.tsx
@@ -28,7 +28,6 @@ export default function PostLayout({ content, next, prev, children }: Props) {
   return (
     <SectionContainer>
       <ScrollIndicator />
-      <TOC />
       <BlogSEO url={`${siteMetadata.siteUrl}/blog/${slug}`} {...content} />
       <ScrollTopAndComment />
       <article className="transition-colors duration-500">
@@ -52,10 +51,11 @@ export default function PostLayout({ content, next, prev, children }: Props) {
             className="divide-y divide-gray-200 pb-8 dark:divide-gray-700 xl:divide-y-0 "
             style={{ gridTemplateRows: 'auto 1fr' }}
           >
-            <div className="divide-y divide-gray-200 dark:divide-gray-700 xl:col-span-3 xl:row-span-2 xl:pb-0">
+            <div className="relative divide-y divide-gray-200 dark:divide-gray-700 xl:col-span-3 xl:row-span-2 xl:pb-0">
               <div className="prose max-w-none pt-10 pb-8 dark:prose-dark">
                 {children}
               </div>
+              <TOC />
             </div>
             <footer>
               <div className="flex flex-col text-sm font-medium sm:flex-row sm:justify-between sm:text-base">

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -49,4 +49,10 @@ export type Toc = {
   url: string;
 }[];
 
+export interface TocElement {
+  id: string;
+  nodeName: string;
+  textContent: string;
+}
+
 export type FileType = 'blog' | 'page';


### PR DESCRIPTION
* Closes #37 

## ✨ 구현 기능 명세
사이드 TOC 컴포넌트를 구현 및 추가했습니다.

## 🎁 PR Point
flex 없이 sticky를 구현하기 위해 `absolute h-full`인 부모로 TOC를 감쌌습니다. flex를 사용하지 않은 이유는 flex로 인해 본문의 width가 TOC 영역까지 늘어나기 때문입니다. absolute로 초기 위치를 정해주고, sticky로 스크롤 이후의 위치를 정해주었습니다.

width를 `w-[calc(49vw-555px)]` 로 TOC의 width를 정해주었습니다. width를 명시해주지 않거나 `w-min`으로 명시해주면 너무 좁은 width로 자동으로 지정되고, `w-max`로 정해줄 경우, view width가 변경되었을 때 overflow 되어 좌우 스크롤이 생겼습니다. 그래서 적절한 width로 `w-[calc(49vw-555px)]` 을 지정해주었습니다.

`useIntersectionObserver` Hook을 좀 더 개선했습니다. useState를 인자로 넘겨주지 않고, heading elements와 currentId를 return 해주도록 변경하였습니다.


## 😭 어려웠던 점

flex 없이 sticky를 구현하는 것이 매우 어려웠습니다. flex로 구현하려고 하니 본문의 width가 예측하지 않은 너비로 변경되어 본문의 너비를 적절하게 지정해주는 방식을 이용하려고 하니, 스크린 사이즈가 제대로 동작하지 않았습니다. sticky를 사용하지 않고 fixed와 자바스크립트를 이용하여 sticky를 구현하려고 했습니다. 하지만 스크롤 이벤트마다 콜백함수가 수행되어야하므로 성능저하가 발생할 것 같아서 `position: sticky`를 사용할 수 있는 방법을 최대한 찾았습니다. 결국 [이 글](https://stackoverflow.com/questions/8328886/sticky-top-div-with-absolute-positioning)을 찾아 문제를 해결할 수 있었습니다.

TOC의 너비를 조절해주는 부분이 어려웠습니다. `width: min-content`와 `width: max-content`는 올바르게 동작하지 않아서 다른 방법들을 최대한 찾아보려고 했으나 모두 제대로 동작하지 않았습니다. 그래서 단순히 하드코딩으로 사이드 빈공간의 너비를 계산하여 `w-[calc(49vw-555px)]` 으로 지정해주는 방식으로 해결하였습니다.

## ⏰ 실제 소요 시간
8h

## 🖥 스크린샷

### 라이트모드
![image](https://user-images.githubusercontent.com/32933980/199880906-5f79955d-03b4-4999-90db-47fb5303b381.png)

### 다크모드
![image](https://user-images.githubusercontent.com/32933980/199880863-5881212c-b469-443f-a9f4-de2c4fc402f6.png)
