### PR TITLE
feat: CategoryList 컴포넌트 구현

### DIFF
--- a/components/CategoryList.tsx
+++ b/components/CategoryList.tsx
@@ -1,0 +1,107 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { GoTriangleDown } from 'react-icons/go';
+import { MdKeyboardArrowLeft, MdKeyboardArrowRight } from 'react-icons/md';
+
+import phrases from '@/data/phrases';
+
+interface Props {
+  categoryTitle: string;
+  series: { title: string; slug: string }[];
+}
+
+const CategoryList = ({ categoryTitle, series }: Props) => {
+  const router = useRouter();
+  const [disclosure, setDisclosure] = useState(true);
+  const curSlug = router.asPath.split('/').at(-1);
+
+  const idx = series.map(({ slug }) => slug).indexOf(curSlug as string) + 1;
+
+  const routeBtns = (
+    <span className="flex items-center justify-center space-x-3">
+      {[
+        {
+          Icon: MdKeyboardArrowLeft,
+          isDisabled: idx === 1,
+          nextIdx: idx - 2,
+        },
+        {
+          Icon: MdKeyboardArrowRight,
+          isDisabled: idx === series.length,
+          nextIdx: idx,
+        },
+      ].map(({ Icon, isDisabled, nextIdx }, index) => (
+        <button
+          className={`rounded-full bg-white dark:bg-gray-700 ${
+            isDisabled
+              ? 'opacity-40'
+              : 'hover:bg-primary-100 hover:dark:bg-primary-900'
+          }`}
+          key={index}
+          onClick={() => router.push(`/blog/${series[nextIdx].slug}`)}
+          disabled={isDisabled}
+        >
+          <Icon className="h-6 w-6 text-primary-500" />
+        </button>
+      ))}
+    </span>
+  );
+
+  return (
+    <div className="mt-5 rounded-md bg-gray-100 px-6 py-5 transition-colors duration-500 dark:bg-gray-800">
+      <svg
+        width="32"
+        height="48"
+        viewBox="0 0 32 48"
+        className="absolute top-0 right-4 h-auto w-6 fill-current text-primary-500 lg:right-6 lg:w-fit"
+      >
+        <path fill="currentColor" d="M32 0H0v48h.163l16-16L32 47.836V0z" />
+      </svg>
+      <header>
+        <Link href={`/categories/${categoryTitle}`}>
+          <a className="mb-7 block inline-block text-xl font-semibold text-gray-700 hover:text-gray-500 hover:underline dark:text-gray-200 hover:dark:text-gray-400 md:text-3xl">
+            {categoryTitle}
+          </a>
+        </Link>
+      </header>
+      {disclosure && (
+        <ol className="list-inside list-decimal space-y-1 marker:italic marker:text-gray-400 marker:before:mr-1 marker:dark:text-gray-500">
+          {series.map(({ slug, title }) => (
+            <li key={slug}>
+              <Link href={`/blog/${slug}`}>
+                <a
+                  className={`hover:underline
+                ${
+                  slug === curSlug
+                    ? 'font-semibold text-primary-500'
+                    : 'text-gray-700 hover:text-gray-900 dark:text-gray-300 hover:dark:text-gray-200'
+                }`}
+                >
+                  {title}
+                </a>
+              </Link>
+            </li>
+          ))}
+        </ol>
+      )}
+      <footer className="flex items-center justify-between">
+        <button
+          className="my-5 flex items-center justify-center text-gray-700 hover:text-gray-900 dark:text-gray-300"
+          onClick={() => setDisclosure((prev) => !prev)}
+        >
+          <GoTriangleDown className={`mr-2 ${disclosure && 'rotate-180'}`} />
+          {disclosure ? phrases.Post.closeCategory : phrases.Post.openCategory}
+        </button>
+        <span className="flex items-center justify-center space-x-5">
+          <span className="dark:text-gray-400">
+            {idx} / {series.length}
+          </span>
+          {routeBtns}
+        </span>
+      </footer>
+    </div>
+  );
+};
+
+export default CategoryList;

--- a/data/phrases.ts
+++ b/data/phrases.ts
@@ -27,6 +27,10 @@ const phrases = {
     noPost: '포스트를 찾을 수 없네요...',
     search: '어떤 글을 찾으시나요?',
   },
+  Post: {
+    openCategory: '목록 보기',
+    closeCategory: '숨기기',
+  },
   SignIn: {
     title: 'Time Gambit 블로그에 어서오세요! 다음으로 로그인 해주세요.',
   },

--- a/layouts/PostSimple.tsx
+++ b/layouts/PostSimple.tsx
@@ -6,6 +6,7 @@ import formatDate from '@/lib/formatDate';
 
 import siteMetadata from '@/data/siteMetadata';
 
+import CategoryList from '@/components/CategoryList';
 import Comments from '@/components/comments';
 import Link from '@/components/Link';
 import PageTitle from '@/components/PageTitle';
@@ -20,9 +21,18 @@ interface Props {
   children: ReactNode;
   next?: { slug: string; title: string };
   prev?: { slug: string; title: string };
+  series?: { slug: string; title: string }[];
+  categoryTitle?: string;
 }
 
-export default function PostLayout({ content, next, prev, children }: Props) {
+export default function PostLayout({
+  content,
+  next,
+  prev,
+  series,
+  categoryTitle,
+  children,
+}: Props) {
   const { slug, date, title } = content;
 
   return (
@@ -52,6 +62,9 @@ export default function PostLayout({ content, next, prev, children }: Props) {
             style={{ gridTemplateRows: 'auto 1fr' }}
           >
             <div className="relative divide-gray-200 dark:divide-gray-700 xl:col-span-3 xl:row-span-2 xl:pb-0">
+              {categoryTitle && series && (
+                <CategoryList categoryTitle={categoryTitle} series={series} />
+              )}
               <div className="prose max-w-none pt-10 pb-8 dark:prose-dark">
                 {children}
               </div>

--- a/pages/blog/[...slug].tsx
+++ b/pages/blog/[...slug].tsx
@@ -35,6 +35,8 @@ export const getStaticProps = async ({
         .map((p) => ({ title: p.title, slug: p.slug }))
     : null;
 
+  const categoryTitle = post.category ?? null;
+
   // prev and next will be a post which draft === false
   const postIndex = sortedPosts.findIndex((p) => p.slug === slug);
   let prevIndex = postIndex - 1,
@@ -62,6 +64,7 @@ export const getStaticProps = async ({
       prev,
       next,
       series,
+      categoryTitle,
     },
   };
 };
@@ -71,6 +74,7 @@ export default function BlogPost({
   prev,
   next,
   series,
+  categoryTitle,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <>
@@ -81,6 +85,8 @@ export default function BlogPost({
           content={post}
           prev={prev}
           next={next}
+          categoryTitle={categoryTitle}
+          series={series}
         />
       ) : (
         <div className="mt-24 text-center">


### PR DESCRIPTION
* Closes #39 

## ✨ 구현 기능 명세
동일한 카테고리의 글 목록을 보여주는 CategoryList 컴포넌트를 구현하였습니다.

## 🎁 PR Point
화살표 버튼의 기능 구현은 next/Link 대신 button과 router.push를 사용했습니다. 그 이유는 아래 서술하겠습니다.

## 😭 어려웠던 점
화살표로 라우팅하는 기능을 구현하는 데에 next/Link 대신 button과 router.push 를 사용했습니다. 처음에는 <Link /> 컴포넌트를 이용하려고 했으나 next/Link 컴포넌트에는 disabled 기능이 없었습니다. 처음에는 이 기능이 당연히 있을 것이라고 생각하여 검색해보았으나 아무리 검색해도 해당 기능은 나오지 않아서 대신 button과 router.push 를 사용했습니다.

## ⏰ 실제 소요 시간
3h 30m

## 🖥 스크린샷

### 라이트모드
![image](https://user-images.githubusercontent.com/32933980/199985653-4d732504-f543-4522-a906-d3894e84cf86.png)

### 다크모드
![image](https://user-images.githubusercontent.com/32933980/199985716-7cbdbf96-23ef-40a1-9ca6-5d6b5aace984.png)
