### PR TITLE
fix: Pre 컴포넌트 children을 nullable로 설정하여 해결

### DIFF
--- a/components/Pre.tsx
+++ b/components/Pre.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useRef, useState } from 'react';
 
 interface Props {
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 const Pre = ({ children }: Props) => {


### PR DESCRIPTION
```
Type error: Type '({ children }: Props) => JSX.Element' is not assignable to type 'keyof IntrinsicElements \| Component<DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement>> \| undefined'.
Type '({ children }: Props) => JSX.Element' is not assignable to type 'FunctionComponent<DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement>>'.
Types of parameters '__0' and 'props' are incompatible.
Type 'DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement>' is not assignable to type 'Props'.
Property 'children' is optional in type 'ClassAttributes<HTMLPreElement> & HTMLAttributes<HTMLPreElement>' but required in type 'Props'.
```

에러 해결