### PR TITLE
feat: category에서 series로 변경 및 PostListInSeries 기능 추가

### DIFF
--- a/components/PostListInSeries.tsx
+++ b/components/PostListInSeries.tsx
@@ -7,13 +7,16 @@ import { MdKeyboardArrowLeft, MdKeyboardArrowRight } from 'react-icons/md';
 import phrases from '@/data/phrases';
 
 interface Props {
-  categoryTitle: string;
+  seriesTitle: string;
   series: { title: string; slug: string }[];
 }
 
-const CategoryList = ({ categoryTitle, series }: Props) => {
+const PostListInSeries = ({ seriesTitle, series }: Props) => {
   const router = useRouter();
-  const [disclosure, setDisclosure] = useState(true);
+  const [disclosure, setDisclosure] = useState(
+    router.query.disclosure === 'true'
+  );
+
   const curSlug = decodeURI(
     (router.asPath.split('/').at(-1) as string).split('#')[0]
   );
@@ -41,7 +44,17 @@ const CategoryList = ({ categoryTitle, series }: Props) => {
               : 'hover:bg-primary-100 hover:dark:bg-primary-900'
           }`}
           key={index}
-          onClick={() => router.push(`/blog/${series[nextIdx].slug}`)}
+          onClick={() =>
+            router.push(
+              {
+                pathname: '/blog/[...slug]',
+                query: {
+                  disclosure,
+                },
+              },
+              `/blog/${series[nextIdx].slug}`
+            )
+          }
           disabled={isDisabled}
         >
           <Icon className="h-6 w-6 text-primary-500" />
@@ -61,9 +74,9 @@ const CategoryList = ({ categoryTitle, series }: Props) => {
         <path fill="currentColor" d="M32 0H0v48h.163l16-16L32 47.836V0z" />
       </svg>
       <header>
-        <Link href={`/categories/${categoryTitle}`}>
+        <Link href={`/series/${seriesTitle}`}>
           <a className="mb-7 block inline-block text-xl font-semibold text-gray-700 hover:text-gray-500 hover:underline dark:text-gray-200 hover:dark:text-gray-400 md:text-3xl">
-            {categoryTitle}
+            {seriesTitle}
           </a>
         </Link>
       </header>
@@ -71,7 +84,13 @@ const CategoryList = ({ categoryTitle, series }: Props) => {
         <ol className="list-inside list-decimal space-y-1 marker:italic marker:text-gray-400 marker:before:mr-1 marker:dark:text-gray-500">
           {series.map(({ slug, title }) => (
             <li key={slug}>
-              <Link href={`/blog/${slug}`}>
+              <Link
+                href={{
+                  pathname: '/blog/[...slug]',
+                  query: { disclosure },
+                }}
+                as={`/blog/${slug}`}
+              >
                 <a
                   className={`hover:underline
                 ${
@@ -93,7 +112,7 @@ const CategoryList = ({ categoryTitle, series }: Props) => {
           onClick={() => setDisclosure((prev) => !prev)}
         >
           <GoTriangleDown className={`mr-2 ${disclosure && 'rotate-180'}`} />
-          {disclosure ? phrases.Post.closeCategory : phrases.Post.openCategory}
+          {disclosure ? phrases.Post.closeSeries : phrases.Post.openSeries}
         </button>
         <span className="flex items-center justify-center space-x-5">
           <span className="dark:text-gray-400">
@@ -106,4 +125,4 @@ const CategoryList = ({ categoryTitle, series }: Props) => {
   );
 };
 
-export default CategoryList;
+export default PostListInSeries;

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -41,7 +41,7 @@ export const Blog = defineDocumentType(() => ({
     images: { type: 'list', of: { type: 'string' } },
     authors: { type: 'list', of: { type: 'string' } },
     layout: { type: 'string' },
-    category: { type: 'string' },
+    series: { type: 'string' },
     bibliography: { type: 'string' },
     canonicalUrl: { type: 'string' },
   },

--- a/data/blog/mdx-컴파일러-비교.mdx
+++ b/data/blog/mdx-컴파일러-비교.mdx
@@ -4,7 +4,7 @@ date: 2022-11-06T14:07:19.674Z
 lastmod: 2022-11-07T14:07:19.674Z
 tags: ['블로그', 'mdx']
 draft: false
-category: 블로그 제작일지
+series: 블로그 제작일지
 summary: 블로그를 제작하면서 next-mdx-remote와 mdx-bundler 중 무엇을 사용할 것인지 고민했었는데, 이 두 라이브러리를 비교한 글입니다.
 images: ['/static/images/blog/make-blog-log/mdx-컴파일러-비교/cover.webp']
 layout: PostSimple

--- a/data/navLinks.ts
+++ b/data/navLinks.ts
@@ -1,7 +1,7 @@
 const navLinks = [
   { href: '/blog', title: 'Blog' },
   { href: '/tags', title: 'Tags' },
-  { href: '/categories', title: 'Categories' },
+  { href: '/series', title: 'Series' },
   { href: '/projects', title: 'Projects' },
   { href: '/about', title: 'About' },
 ];

--- a/data/phrases.ts
+++ b/data/phrases.ts
@@ -28,8 +28,8 @@ const phrases = {
     search: '어떤 글을 찾으시나요?',
   },
   Post: {
-    openCategory: '목록 보기',
-    closeCategory: '숨기기',
+    openSeries: '목록 보기',
+    closeSeries: '숨기기',
   },
   SignIn: {
     title: 'Time Gambit 블로그에 어서오세요! 다음으로 로그인 해주세요.',

--- a/layouts/PostSimple.tsx
+++ b/layouts/PostSimple.tsx
@@ -6,7 +6,7 @@ import useFormattedDate from '@/hooks/useFormattedDate';
 
 import siteMetadata from '@/data/siteMetadata';
 
-import CategoryList from '@/components/CategoryList';
+import PostListInSeries from '@/components/PostListInSeries';
 import Comments from '@/components/comments';
 import Link from '@/components/Link';
 import PageTitle from '@/components/PageTitle';
@@ -22,7 +22,7 @@ interface Props {
   next?: { slug: string; title: string };
   prev?: { slug: string; title: string };
   series?: { slug: string; title: string }[];
-  categoryTitle?: string;
+  seriesTitle?: string;
 }
 
 export default function PostLayout({
@@ -30,7 +30,7 @@ export default function PostLayout({
   next,
   prev,
   series,
-  categoryTitle,
+  seriesTitle,
   children,
 }: Props) {
   const { slug, date, title } = content;
@@ -64,8 +64,8 @@ export default function PostLayout({
             style={{ gridTemplateRows: 'auto 1fr' }}
           >
             <div className="relative divide-gray-200 dark:divide-gray-700 xl:col-span-3 xl:row-span-2 xl:pb-0">
-              {categoryTitle && series && (
-                <CategoryList categoryTitle={categoryTitle} series={series} />
+              {seriesTitle && series && (
+                <PostListInSeries seriesTitle={seriesTitle} series={series} />
               )}
               <div className="prose max-w-none pt-10 pb-8 dark:prose-dark">
                 {children}

--- a/lib/getBlogInfo.mjs
+++ b/lib/getBlogInfo.mjs
@@ -19,11 +19,11 @@ export async function getAllTags() {
   return tagCount;
 }
 
-const categorySet = new Set();
-export async function getAllCategories() {
-  if (categorySet.size) return categorySet;
+const seriesSet = new Set();
+export async function getAllSeries() {
+  if (seriesSet.size) return seriesSet;
   allBlogs.forEach(
-    ({ category }) => category && categorySet.add(GithubSlugger.slug(category))
+    ({ series }) => series && seriesSet.add(GithubSlugger.slug(series))
   );
-  return categorySet;
+  return seriesSet;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,7 +28,7 @@ export interface PostFrontMatter {
   slug: string;
   views?: string;
 
-  category?: string;
+  series?: string;
   tags?: string[];
 }
 

--- a/pages/blog/[...slug].tsx
+++ b/pages/blog/[...slug].tsx
@@ -26,17 +26,17 @@ export const getStaticProps = async ({
 
   // If post is included in category, sortedPosts are category posts
   const sortedPosts = sortedBlogPost(
-    post?.category
-      ? allBlogs.filter((p) => p.category === post.category)
-      : allBlogs.filter((p) => !p.category)
+    post?.series
+      ? allBlogs.filter((p) => p.series === post.series)
+      : allBlogs.filter((p) => !p.series)
   );
-  const series = post.category
+  const series = post.series
     ? sortedPosts
         .filter((p) => !p.draft)
         .map((p) => ({ title: p.title, slug: p.slug }))
     : null;
 
-  const categoryTitle = post.category ?? null;
+  const seriesTitle = post.series ?? null;
 
   // prev and next will be a post which draft === false
   const postIndex = sortedPosts.findIndex((p) => p.slug === slug);
@@ -65,7 +65,7 @@ export const getStaticProps = async ({
       prev,
       next,
       series,
-      categoryTitle,
+      seriesTitle,
     },
   };
 };
@@ -75,7 +75,7 @@ export default function BlogPost({
   prev,
   next,
   series,
-  categoryTitle,
+  seriesTitle,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <>
@@ -86,7 +86,7 @@ export default function BlogPost({
           content={post}
           prev={prev}
           next={next}
-          categoryTitle={categoryTitle}
+          seriesTitle={seriesTitle}
           series={series}
         />
       ) : (

--- a/pages/categories/index.tsx
+++ b/pages/categories/index.tsx
@@ -1,3 +1,0 @@
-export default function CategoriesPage() {
-  return <div>카테고리</div>;
-}

--- a/pages/series/index.tsx
+++ b/pages/series/index.tsx
@@ -1,0 +1,3 @@
+export default function SeriesPage() {
+  return <div>시리즈</div>;
+}

--- a/scripts/generate-rss.mjs
+++ b/scripts/generate-rss.mjs
@@ -5,7 +5,7 @@ import path from "path";
 import { escape } from "./htmlEscaper.mjs";
 import { allBlogs } from "../.contentlayer/generated/Blog/_index.mjs";
 import siteMetadata from "../data/siteMetadata.js";
-import { getAllCategories, getAllTags } from "../lib/getBlogInfo.mjs";
+import { getAllSeries, getAllTags } from "../lib/getBlogInfo.mjs";
 
 const generateRssItem = (post) => `
   <item>
@@ -64,7 +64,7 @@ const generateRss = (posts, page = "feed.xml") => `
 
   // RSS for categories
   if (allBlogs.length > 0) {
-    const categories = await getAllCategories();
+    const categories = await getAllSeries();
     for (const category of categories) {
       const filteredPosts = allBlogs.filter(
         (post) =>

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -13,7 +13,7 @@ import siteMetadata from '../data/siteMetadata.js';
   const pages = await globby([
     'pages/*.{js|tsx}',
     'public/tags/**/*.xml',
-    'public/categories/**/*.xml',
+    'public/series/**/*.xml',
     '!pages/_*.{js|tsx}',
     '!pages/api',
     '!pages/404.{js|tsx}',


### PR DESCRIPTION
* Closes #67 

## ✨ 구현 기능 명세
기존의 Categories와 관련된 이름들을 Series로 변경했습니다. 

PostListInSeries(기존의 CategoryList) 컴포넌트의 기능을 조금 변경했습니다.
* 기본은 닫혀있는 것으로 변경하였습니다.
* 열려있는 상태로 다른 글로 이동하였을 때, 여전히 열려있도록 수정하였습니다.

## 🎁 PR Point
PostListInSeries 에서 <Link /> 및 useRouter를 이용해 라우팅할 때 query를 이용하여 disclosure 상태를 전달하였습니다.

## 😭 어려웠던 점
query를 이용해 boolean을 전달했는데 string으로 상태가 전달되어 왜 이런 것인지 파악하는데 오래걸렸습니다. url은 boolean도 string일 수 밖에 없으므로 string이나 string[]으로만 전달되는 것을 알게되었습니다.

## ⏰ 실제 소요 시간
1h 40m
