### PR TITLE
post 페이지 x축 padding 줄이기

### DIFF
--- a/components/TOC/SmallWidthTOC.tsx
+++ b/components/TOC/SmallWidthTOC.tsx
@@ -12,8 +12,8 @@ const SmallWidthTOC = () => {
   return (
     <div className="2xl:hidden">
       <button
-        className={`sm:top-13 fixed right-0 top-14 rounded-l-md border-y-2 border-l-2 border-primary-700 bg-primary-500 
-        px-2 py-1 text-gray-100 duration-500 dark:border-primary-500 dark:bg-primary-700 dark:text-gray-200
+        className={`fixed right-0 top-[59px] rounded-l-md border-y-2 border-l-2 border-primary-700 bg-primary-500 px-2 py-1 
+        text-gray-100 duration-500 dark:border-primary-500 dark:bg-primary-700 dark:text-gray-200 sm:top-[50px]
         ${scrollDirection === 'down' ? '-right-[50px]' : 'right-0'} 
         `}
         onClick={() => setTocShow(true)}
@@ -21,9 +21,9 @@ const SmallWidthTOC = () => {
         TOC
       </button>
       <article
-        className={`sm:top-13 fixed top-[56px] h-5/6 w-80 overflow-y-scroll rounded-l-lg 
-        border-y-2 border-l-2 border-primary-700 bg-white duration-500 scrollbar-hide 
-        dark:bg-gray-900 ${tocShow ? 'right-0' : '-right-80'}
+        className={`fixed top-[59px] h-fit max-h-[85vh] w-80 overflow-y-scroll rounded-l-lg border-y-2 
+        border-l-2 border-primary-700 bg-white duration-500 scrollbar-hide dark:bg-gray-900 
+        sm:top-[50px] ${tocShow ? 'right-0' : '-right-80'}
         `}
       >
         <button

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -51,7 +51,7 @@ export default function Header() {
       }`}
     >
       <Link href="/" aria-label={siteMetadata.headerTitle}>
-        <div className="flex cursor-pointer items-center justify-between">
+        <a className="flex cursor-pointer items-center justify-between">
           <div className="mr-3">
             <Logo className="h-7 w-7 fill-current text-primary-500 dark:text-primary-300" />
           </div>
@@ -62,7 +62,7 @@ export default function Header() {
           ) : (
             siteMetadata.headerTitle
           )}
-        </div>
+        </a>
       </Link>
       <div className="flex items-center text-base leading-5">
         <div className="hidden sm:block">{navItems}</div>

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -47,7 +47,7 @@ export default function Header() {
   return (
     <header
       className={`w-section fixed left-0 right-0 z-10 flex items-center justify-between border-b-2 bg-white py-2 transition-all duration-500 dark:bg-gray-900 ${
-        scrollDirection === 'down' ? '-top-24' : 'top-0'
+        scrollDirection === 'down' ? '-top-[60px] sm:-top-14' : 'top-0'
       }`}
     >
       <Link href="/" aria-label={siteMetadata.headerTitle}>

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -68,7 +68,7 @@ input:-webkit-autofill:focus {
     }
 
     .w-section {
-        @apply mx-auto max-w-3xl px-4 sm:px-6 xl:max-w-5xl xl:px-0;
+        @apply mx-auto max-w-3xl px-4 xl:max-w-5xl xl:px-0;
     }
 
     .card {

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -13,7 +13,6 @@ import ScrollIndicator from '@/components/blog/ScrollIndicator';
 import ScrollTopAndComment from '@/components/blog/ScrollTopAndComment';
 import ViewCounter from '@/components/blog/ViewCounter';
 import Comments from '@/components/comments';
-import SectionContainer from '@/components/common/SectionContainer';
 import { BlogSEO } from '@/components/common/SEO';
 import Link from '@/components/mdxComponents/CustomLink';
 import LargeWidthTOC from '@/components/TOC/LargeWidthTOC';
@@ -39,7 +38,7 @@ export default function PostLayout({
   const { slug, date, title } = content;
 
   return (
-    <SectionContainer>
+    <>
       <ScrollIndicator />
       <BlogSEO url={`${siteMetadata.siteUrl}/blog/${slug}`} {...content} />
       <ScrollTopAndComment />
@@ -105,6 +104,6 @@ export default function PostLayout({
           </div>
         </div>
       </article>
-    </SectionContainer>
+    </>
   );
 }


### PR DESCRIPTION
* Closes #153 

## ✨ 구현 기능 명세
post 페이지에 x축 padding을 줄였습니다. 

## 🎁 PR Point
SectionContainer가 중복해서 적용되어 발생한 문제였습니다. 이 문제를 `PostLayout`에 SectionContainer를 Fragment로 변경하여 해결하였습니다.

Header의 로고는 Link 태그로 되어있는데, 이 태그 내에 a태그 대신 div 태그가 들어있었습니다. 이를 a 태그로 바꿔주었습니다.

## ⏰ 실제 소요 시간
20m

## 🖥 스크린샷

![image](https://user-images.githubusercontent.com/32933980/205416884-ee79cd80-78b0-46c9-b8f7-823426ba063a.png)
