### PR TITLE
SEO 태그 버그 해결

### DIFF
--- a/components/blog/PostListInSeries.tsx
+++ b/components/blog/PostListInSeries.tsx
@@ -109,7 +109,7 @@ const PostListInSeries = ({ seriesTitle, series }: Props) => {
           onClick={() => setDisclosure((prev) => !prev)}
         >
           <GoTriangleDown className={`mr-2 ${disclosure && 'rotate-180'}`} />
-          {disclosure ? phrases.Post.closeSeries : phrases.Post.openSeries}
+          {disclosure ? phrases.Blog.closeSeries : phrases.Blog.openSeries}
         </button>
         <span className="flex items-center justify-center space-x-5">
           <span className="dark:text-gray-400">

--- a/components/comments/Giscus.tsx
+++ b/components/comments/Giscus.tsx
@@ -66,7 +66,7 @@ const Giscus = () => {
     <div className="pt-6 pb-6 text-center text-gray-700 dark:text-gray-300">
       {enableLoadComments && (
         <button onClick={LoadComments} className="hover:underline md:text-lg">
-          {phrases.Post.loadComments}
+          {phrases.Blog.loadComments}
         </button>
       )}
       <div className="giscus" id={COMMENTS_ID} />

--- a/components/common/SEO.tsx
+++ b/components/common/SEO.tsx
@@ -3,8 +3,10 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 
 import { CoreContent } from '@/lib/contentlayer';
+import { getImageWithFallback } from '@/lib/utils';
 
 import siteMetadata from '@/data/siteMetadata';
+
 interface CommonSEOProps {
   title: string;
   description: string;
@@ -72,22 +74,28 @@ interface PageSEOProps {
 }
 
 export const PageSEO = ({ title, description, image }: PageSEOProps) => {
-  const ogImageUrl = image || siteMetadata.siteUrl + siteMetadata.socialBanner;
-  const twImageUrl = image || siteMetadata.siteUrl + siteMetadata.socialBanner;
+  const ogImageUrl =
+    image ||
+    getImageWithFallback(
+      siteMetadata.socialBanner,
+      siteMetadata.siteUrl + siteMetadata.socialBanner
+    );
   return (
     <CommonSEO
       title={title}
       description={description}
       ogType="website"
       ogImage={ogImageUrl}
-      twImage={twImageUrl}
+      twImage={ogImageUrl}
     />
   );
 };
 
 export const TagSEO = ({ title, description }: PageSEOProps) => {
-  const ogImageUrl = siteMetadata.siteUrl + siteMetadata.socialBanner;
-  const twImageUrl = siteMetadata.siteUrl + siteMetadata.socialBanner;
+  const ogImageUrl = getImageWithFallback(
+    siteMetadata.socialBanner,
+    siteMetadata.siteUrl + siteMetadata.socialBanner
+  );
   const router = useRouter();
   return (
     <>
@@ -96,7 +104,7 @@ export const TagSEO = ({ title, description }: PageSEOProps) => {
         description={description}
         ogType="website"
         ogImage={ogImageUrl}
-        twImage={twImageUrl}
+        twImage={ogImageUrl}
       />
       <Head>
         <link
@@ -135,7 +143,7 @@ export const BlogSEO = ({
   const featuredImages = imagesArr.map((img) => {
     return {
       '@type': 'ImageObject',
-      url: `${siteMetadata.siteUrl}${img}`,
+      url: getImageWithFallback(img, `${siteMetadata.siteUrl}${img}`),
     };
   });
 
@@ -155,7 +163,10 @@ export const BlogSEO = ({
       name: siteMetadata.author,
       logo: {
         '@type': 'ImageObject',
-        url: `${siteMetadata.siteUrl}${siteMetadata.siteLogo}`,
+        url: getImageWithFallback(
+          siteMetadata.siteLogo,
+          `${siteMetadata.siteUrl}${siteMetadata.siteLogo}`
+        ),
       },
     },
     description: summary,

--- a/data/phrases.ts
+++ b/data/phrases.ts
@@ -28,8 +28,6 @@ const phrases = {
     search: '어떤 글을 찾으시나요?',
     prev: '이전 포스트',
     next: '다음 포스트',
-  },
-  Post: {
     openSeries: '목록 보기',
     closeSeries: '숨기기',
     loadComments: '댓글 불러오기',
@@ -49,10 +47,16 @@ const phrases = {
     noSeries: '시리즈로 작성된 글이 없습니다!',
   },
   Seo: {
-    defaultDesc: 'Time Gambit의 블로그',
+    homeDesc: 'Time Gambit의 블로그',
     dashboardDesc: '대시보드',
-    projectsDesc: '개발해온 프로젝트',
-    guestbookDesc: '게스트북',
+    projectsDesc: 'Time Gambit의 프로젝트',
+    guestbookDesc: 'Time Gambit 블로그 방명록',
+    seriesDesc: 'Time Gambit이 작성한 시리즈 목록',
+    blogDesc: 'Time Gambit이 작성한 포스트 목록',
+    tagDesc: 'Time Gambit 블로그에 작성된 태그 목록',
+    aboutDesc: 'Time Gambit 소개',
+    specificTagDesc: 'tag #? 포스트 목록',
+    specificSeriesDesc: 'series [?] 포스트 목록',
   },
   Guestbook: {
     title: 'Guestbook',

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,4 @@
+const getImageWithFallback = (url: string, fallbackUrl: string) =>
+  url.startsWith('http') ? url : fallbackUrl;
+
+export { getImageWithFallback };

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,5 +1,7 @@
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 
+import siteMetadata from '@/data/siteMetadata';
+
 class MyDocument extends Document {
   render() {
     return (
@@ -75,7 +77,7 @@ class MyDocument extends Document {
             href="/static/favicons/favicon-128.png"
             sizes="128x128"
           />
-          <meta name="application-name" content="&nbsp;" />
+          <meta name="application-name" content={siteMetadata.title} />
           <meta name="msapplication-TileColor" content="#FFFFFF" />
           <meta name="msapplication-TileImage" content="mstile-144x144.png" />
           <meta

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -15,7 +15,7 @@ export default function AboutPage() {
     <>
       <PageSEO
         title={`About - ${siteMetadata.author}`}
-        description={siteMetadata.description}
+        description={phrases.Seo.aboutDesc || siteMetadata.description}
       />
       <h1 className="basic-text text-3xl font-extrabold md:text-5xl">
         {title}

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -30,7 +30,7 @@ export default function BlogPage({
     <>
       <PageSEO
         title={`Blog - ${siteMetadata.author}`}
-        description={siteMetadata.description}
+        description={phrases.Seo.blogDesc || siteMetadata.description}
       />
       <ListLayout
         posts={posts as PostListItem[]}

--- a/pages/guestbook.tsx
+++ b/pages/guestbook.tsx
@@ -38,7 +38,7 @@ export default function GuestbookPage({
     <>
       <PageSEO
         title={`Guestbook - ${siteMetadata.author}`}
-        description="블로그 방명록"
+        description={phrases.Seo.guestbookDesc || siteMetadata.description}
       />
       <>
         <div className="divide-y">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -27,7 +27,10 @@ export default function Home({
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <>
-      <PageSEO title="Time Gambit" description={siteMetadata.description} />
+      <PageSEO
+        title={siteMetadata.title}
+        description={phrases.Seo.homeDesc || siteMetadata.description}
+      />
       <main className="flex flex-1 flex-col">
         <Introduction />
         <div className="flex justify-between">

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -10,7 +10,7 @@ export default function ProjectsPage() {
     <>
       <PageSEO
         title={`Projects - ${siteMetadata.author}`}
-        description={siteMetadata.description}
+        description={phrases.Seo.projectsDesc || siteMetadata.description}
       />
       <div className="divide-y divide-gray-200 dark:divide-gray-700">
         <div className="space-y-2 pt-6 pb-8 md:space-y-5">

--- a/pages/series.tsx
+++ b/pages/series.tsx
@@ -22,7 +22,7 @@ export default function SeriesPage({
     <>
       <PageSEO
         title={`Series - ${siteMetadata.author}`}
-        description={siteMetadata.description}
+        description={phrases.Seo.seriesDesc || siteMetadata.description}
       />
       <div className="divide-y divide-gray-200 dark:divide-gray-700">
         <div className="space-y-2 pt-6 pb-8 md:space-y-5">

--- a/pages/series/[seriesSlug].tsx
+++ b/pages/series/[seriesSlug].tsx
@@ -5,7 +5,9 @@ import { InferGetStaticPropsType } from 'next';
 import { pickBlogItem, sortedBlogPost } from '@/lib/contentlayer';
 import { getAllSeries } from '@/lib/getBlogInfo.mjs';
 import { PostListItem, SeriesListItem } from '@/lib/types';
+import { getImageWithFallback } from '@/lib/utils';
 
+import phrases from '@/data/phrases';
 import seriesData from '@/data/seriesData';
 import siteMetadata from '@/data/siteMetadata';
 
@@ -56,8 +58,14 @@ export default function SeriesPost({
     <>
       <PageSEO
         title={`Series | ${series['title']} - ${siteMetadata.author}`}
-        description={siteMetadata.description}
-        image={siteMetadata.siteUrl + series['image']}
+        description={
+          phrases.Seo.specificSeriesDesc?.replace('?', series['title']) ||
+          `[${series['title']}] series - ${siteMetadata.author}`
+        }
+        image={getImageWithFallback(
+          series['image'],
+          siteMetadata.siteUrl + series['image']
+        )}
       />
       <ListLayout posts={posts as PostListItem[]} title={series['title']} />
     </>

--- a/pages/tags.tsx
+++ b/pages/tags.tsx
@@ -3,6 +3,7 @@ import { GetStaticProps, InferGetStaticPropsType } from 'next';
 
 import { getAllTags } from '@/lib/getBlogInfo.mjs';
 
+import phrases from '@/data/phrases';
 import siteMetadata from '@/data/siteMetadata';
 
 import { PageSEO } from '@/components/common/SEO';
@@ -25,7 +26,7 @@ export default function TagListPage({
     <>
       <PageSEO
         title={`Tags - ${siteMetadata.author}`}
-        description="블로그 태그"
+        description={phrases.Seo.tagDesc || siteMetadata.description}
       />
       <div className="flex flex-col items-start justify-start divide-y divide-gray-200 dark:divide-gray-700 md:mt-24 md:flex-row md:items-center md:justify-center md:space-x-6 md:divide-y-0">
         <div className="space-x-2 pt-6 pb-8 md:space-y-5">

--- a/pages/tags/[tag].tsx
+++ b/pages/tags/[tag].tsx
@@ -6,6 +6,7 @@ import { pickBlogItem, sortedBlogPost } from '@/lib/contentlayer';
 import { getAllTags } from '@/lib/getBlogInfo.mjs';
 import { PostListItem } from '@/lib/types';
 
+import phrases from '@/data/phrases';
 import siteMetadata from '@/data/siteMetadata';
 
 import { TagSEO } from '@/components/common/SEO';
@@ -50,8 +51,11 @@ export default function TagPostListPage({
   return (
     <>
       <TagSEO
-        title={`${tag} - ${siteMetadata.title}`}
-        description={`${tag} tags - ${siteMetadata.author}`}
+        title={`Tags | ${tag} - ${siteMetadata.author}`}
+        description={
+          phrases.Seo.specificTagDesc?.replace('?', tag) ||
+          `#${tag} tags - ${siteMetadata.author}`
+        }
       />
       <ListLayout posts={posts as PostListItem[]} title={tag} />
     </>


### PR DESCRIPTION
* Closes #184 

## ✨ 구현 기능 명세
SEO를 위한 태그들에 올바르지 않은 값들이 들어가는 버그를 해결하였습니다.

## 🎁 PR Point
1. phrases.Seo에 각 페이지의 SEO 컴포넌트의 description 값들을 넣고 이를 이용하도록 구현하였습니다.
2. Seo 컴포넌트에서 imageUrl에 들어있는 값이 절대경로일 경우 이를 그대로 이용하고, 상대경로일 경우 siteMetadata의 siteUrl을 앞에 붙여 사용하도록 변경하였습니다.

## ⏰ 실제 소요 시간
2h 30m
