### PR TITLE
블로그 포스트 seo 에러 해결

### DIFF
--- a/components/common/SEO.tsx
+++ b/components/common/SEO.tsx
@@ -185,7 +185,7 @@ export const BlogSEO = ({
       <CommonSEO
         title={title}
         description={summary || siteMetadata.description}
-        ogType="article"
+        ogType="website"
         ogImage={featuredImages}
         twImage={twImageUrl}
         canonicalUrl={canonicalUrl}

--- a/components/common/SEO.tsx
+++ b/components/common/SEO.tsx
@@ -186,8 +186,8 @@ export const BlogSEO = ({
         title={title}
         description={summary || siteMetadata.description}
         ogType="article"
-        ogImage={siteMetadata.siteUrl + siteMetadata.socialBanner}
-        twImage={siteMetadata.siteUrl + siteMetadata.socialBanner}
+        ogImage={featuredImages}
+        twImage={twImageUrl}
         canonicalUrl={canonicalUrl}
       />
       <Head>

--- a/components/common/SEO.tsx
+++ b/components/common/SEO.tsx
@@ -51,7 +51,9 @@ const CommonSEO = ({
         <meta property="og:image" content={ogImage} key={ogImage} />
       )}
       <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:site" content={siteMetadata.twitter} />
+      {siteMetadata.twitter && (
+        <meta name="twitter:site" content={siteMetadata.twitter} />
+      )}
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
       <meta name="twitter:image" content={twImage} />
@@ -158,6 +160,10 @@ export const BlogSEO = ({
     image: featuredImages,
     datePublished: publishedAt,
     dateModified: modifiedAt,
+    author: {
+      '@type': 'Person',
+      name: siteMetadata.author,
+    },
     publisher: {
       '@type': 'Organization',
       name: siteMetadata.author,
@@ -178,7 +184,7 @@ export const BlogSEO = ({
     <>
       <CommonSEO
         title={title}
-        description={summary ?? siteMetadata.description}
+        description={summary || siteMetadata.description}
         ogType="article"
         ogImage={featuredImages}
         twImage={twImageUrl}

--- a/components/common/SEO.tsx
+++ b/components/common/SEO.tsx
@@ -185,9 +185,9 @@ export const BlogSEO = ({
       <CommonSEO
         title={title}
         description={summary || siteMetadata.description}
-        ogType="website"
-        ogImage={featuredImages}
-        twImage={twImageUrl}
+        ogType="article"
+        ogImage={siteMetadata.siteUrl + siteMetadata.socialBanner}
+        twImage={siteMetadata.siteUrl + siteMetadata.socialBanner}
         canonicalUrl={canonicalUrl}
       />
       <Head>

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -76,7 +76,7 @@ export default function PostLayout({
               </div>
               <LargeWidthTOC />
               <SmallWidthTOC />
-              <div className="flex gap-3">
+              <div className="flex flex-wrap gap-3">
                 {tags?.map((tag) => (
                   <TagInPost key={tag} title={tag} />
                 ))}

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -13,7 +13,6 @@ import ScrollTopAndComment from '@/components/blog/ScrollTopAndComment';
 import TagInPost from '@/components/blog/TagInPost';
 import ViewCounter from '@/components/blog/ViewCounter';
 import Comments from '@/components/comments';
-import { PageSEO } from '@/components/common/SEO';
 import LargeWidthTOC from '@/components/TOC/LargeWidthTOC';
 import SmallWidthTOC from '@/components/TOC/SmallWidthTOC';
 
@@ -39,12 +38,6 @@ export default function PostLayout({
   return (
     <>
       <ScrollIndicator />
-      {/*<BlogSEO url={`${siteMetadata.siteUrl}/blog/${slug}`} {...content} />*/}
-      <PageSEO
-        title={title}
-        description={content.summary as string}
-        image={content.images?.[0]}
-      />
       <ScrollTopAndComment />
       <article className="transition-colors duration-500">
         <div>

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -5,8 +5,6 @@ import { CoreContent } from '@/lib/contentlayer';
 import { isProd } from '@/lib/isProduction';
 import useFormattedDate from '@/hooks/useFormattedDate';
 
-import siteMetadata from '@/data/siteMetadata';
-
 import PageTitle from '@/components/blog/PageTitle';
 import PostListInSeries from '@/components/blog/PostListInSeries';
 import RoutePostBtn from '@/components/blog/RoutePostBtn';
@@ -15,7 +13,7 @@ import ScrollTopAndComment from '@/components/blog/ScrollTopAndComment';
 import TagInPost from '@/components/blog/TagInPost';
 import ViewCounter from '@/components/blog/ViewCounter';
 import Comments from '@/components/comments';
-import { BlogSEO } from '@/components/common/SEO';
+import { PageSEO } from '@/components/common/SEO';
 import LargeWidthTOC from '@/components/TOC/LargeWidthTOC';
 import SmallWidthTOC from '@/components/TOC/SmallWidthTOC';
 
@@ -41,7 +39,12 @@ export default function PostLayout({
   return (
     <>
       <ScrollIndicator />
-      <BlogSEO url={`${siteMetadata.siteUrl}/blog/${slug}`} {...content} />
+      {/*<BlogSEO url={`${siteMetadata.siteUrl}/blog/${slug}`} {...content} />*/}
+      <PageSEO
+        title={title}
+        description={content.summary as string}
+        image={content.images?.[0]}
+      />
       <ScrollTopAndComment />
       <article className="transition-colors duration-500">
         <div>

--- a/pages/blog/[...slug].tsx
+++ b/pages/blog/[...slug].tsx
@@ -3,7 +3,10 @@ import { InferGetStaticPropsType } from 'next';
 
 import { coreContent, sortedBlogPost } from '@/lib/contentlayer';
 
+import siteMetadata from '@/data/siteMetadata';
+
 import PageTitle from '@/components/blog/PageTitle';
+import { BlogSEO } from '@/components/common/SEO';
 import { MDXLayoutRenderer } from '@/components/mdxComponents/MDXComponents';
 
 const DEFAULT_LAYOUT = 'PostLayout';
@@ -81,14 +84,20 @@ export default function BlogPost({
   return (
     <>
       {'draft' in post && post['draft'] !== true ? (
-        <MDXLayoutRenderer
-          layout={post['layout'] || DEFAULT_LAYOUT}
-          content={post}
-          prev={prev}
-          next={next}
-          seriesTitle={seriesTitle}
-          series={series}
-        />
+        <>
+          <BlogSEO
+            url={`${siteMetadata.siteUrl}/blog/${post.slug}`}
+            {...post}
+          />
+          <MDXLayoutRenderer
+            layout={post['layout'] || DEFAULT_LAYOUT}
+            content={post}
+            prev={prev}
+            next={next}
+            seriesTitle={seriesTitle}
+            series={series}
+          />
+        </>
       ) : (
         <div className="mt-24 text-center">
           <PageTitle>


### PR DESCRIPTION
## ✨ 구현 기능 명세
블로그 포스트의 seo 문제를 해결합니다.

## 🎁 PR Point
`BlogSEO` 컴포넌트를 PostLayout에서 /pages/blog/[...slug] 로 옮겼습니다.

## 😭 어려웠던 점
원인 파악이 매우매우 어려웠습니다. 원인은 dynamic import로 인해 SEO를 위한 메타태그가 나중에 생겨서 발생한 문제였습니다

## ⏰ 실제 소요 시간
5h

## 🖥 스크린샷
![image](https://user-images.githubusercontent.com/32933980/206334820-46547a43-7d0e-4503-9851-795317557870.png)
