### PR TITLE
Hotfix/0.10.3: bs 아이콘 io5 아이콘으로 교체

### DIFF
--- a/components/blog/RoutePostBtn.tsx
+++ b/components/blog/RoutePostBtn.tsx
@@ -1,5 +1,8 @@
-import dynamic from 'next/dynamic';
 import Link from 'next/link';
+import {
+  IoArrowBackCircleOutline,
+  IoArrowForwardCircleOutline,
+} from 'react-icons/io5';
 
 import phrases from '@/data/phrases';
 
@@ -16,17 +19,15 @@ const RoutePostBtn = ({ title, slug, direction, empty }: Props) => {
     return <div className="h-full w-full md:w-1/2" />;
   }
 
-  const Arrow = dynamic(() =>
-    import('react-icons/bs').then(
-      (res) =>
-        res[direction === 'prev' ? 'BsArrowLeftCircle' : 'BsArrowRightCircle']
-    )
-  );
+  const Arrow =
+    direction === 'prev'
+      ? IoArrowBackCircleOutline
+      : IoArrowForwardCircleOutline;
 
   return (
     <Link
       href={`/blog/${slug}`}
-      className={`group flex w-full items-center gap-4 rounded-md bg-gray-100 py-2
+      className={`group flex w-full items-center gap-2 rounded-md bg-gray-100 py-2
         px-3 text-2xl font-semibold duration-300 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 md:w-1/2 ${
           direction === 'prev'
             ? 'flex-row-reverse justify-start'
@@ -46,7 +47,7 @@ const RoutePostBtn = ({ title, slug, direction, empty }: Props) => {
         </div>
       </div>
       <Arrow
-        className={`h-7 w-7 fill-current text-primary-500 ${
+        className={`h-9 w-9 fill-current text-primary-500 ${
           direction === 'prev'
             ? 'group-hover:animate-bounce-left'
             : 'group-hover:animate-bounce-right'


### PR DESCRIPTION
## ✨ 구현 기능 명세
BS 아이콘에서 io5 아이콘으로 교체하였습니다.

## 🎁 PR Point
dynamic import에서 그냥 import로 아이콘을 불러옵니다.

## 😭 어려웠던 점
BS 모듈의 버그로 인해 발생하는 문제라고 생각하였습니다. 그래서 소스코드를 직접 보았는데 다른 모듈과의 차이점이 전혀 없었습니다. 프로젝트를 fork 하여 코드도 분석해보았습니다만, BS 아이콘 모듈이 다른 모듈과 다른 점이 없었습니다.

그래서 새로운 프로젝트를 생성하여 BS 모듈을 import 해보았습니다만, 새 프로젝트에서는 전혀 문제가 없었습니다. 이로 인해 구체적인 원인을 파악하지 못하고 해결만하게 되었습니다. 추후에 좀 더 분석을 해보아야 할 것 같습니다.

## ⏰ 실제 소요 시간
1h

## 🖥 스크린샷

### 수정 전
<img width="533" alt="reduce-js" src="https://user-images.githubusercontent.com/32933980/207477157-72325ac5-e312-484e-b7ea-14daf0a3c85b.png">
BS아이콘 사용으로 인해 `Reduce unused JavaScript`을 경고합니다.

### 수정 후
<img width="535" alt="no-reduce-js" src="https://user-images.githubusercontent.com/32933980/207477171-71a90e67-c793-4ac7-90ba-ec1bd5455f9d.png">
io5로 교체되어 더이상 `Reduce unused JavaScript` 경고가 나오지 않습니다.
