### PR TITLE
guestbook 로그아웃시 spinner 보여주기

### DIFF
--- a/components/Guestbook/GuestbookInput.tsx
+++ b/components/Guestbook/GuestbookInput.tsx
@@ -84,7 +84,10 @@ const GuestbookInput = ({ setLoading, user }: Props) => {
         </div>
         <button
           className="w-24 rounded-md bg-primary-200 py-2 dark:bg-primary-700"
-          onClick={() => signOut()}
+          onClick={() => {
+            setLoading(true);
+            signOut().finally(() => setLoading(false));
+          }}
         >
           {phrases.Guestbook.logout}
         </button>

--- a/components/Guestbook/GuestbookInput.tsx
+++ b/components/Guestbook/GuestbookInput.tsx
@@ -86,7 +86,7 @@ const GuestbookInput = ({ setLoading, user }: Props) => {
           className="w-24 rounded-md bg-primary-200 py-2 dark:bg-primary-700"
           onClick={() => {
             setLoading(true);
-            signOut().finally(() => setLoading(false));
+            signOut().catch(() => setLoading(false));
           }}
         >
           {phrases.Guestbook.logout}


### PR DESCRIPTION
* Closes #224 

## ✨ 구현 기능 명세
guestbook 페이지에서 로그아웃할 때에도 로딩 spinner를 보여줍니다.

## 🎁 PR Point
`signOut().catch(() => setLoading(false))`로 로그아웃이 실패할 때에만 loading이 false로 바뀌도록 하였습니다. 성공시에는 자동으로 /guestbook 페이지로 리다이렉트되어 setLoading(false)를 해줄 필요가 없기 때문입니다.

## ⏰ 실제 소요 시간
10m
