### PR TITLE
ListLayout 무한스크롤 구현

### DIFF
--- a/components/blog/ViewCounter.tsx
+++ b/components/blog/ViewCounter.tsx
@@ -20,7 +20,7 @@ const ViewCounter = ({ slug, type = 'POST', shown = false }: Props) => {
     localStorage.setItem(LAST_POST, slug);
 
     increment();
-  }, []);
+  }, [increment, slug, type]);
 
   // when no need to show & fetching is error
   if (!shown || isError) return null;

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -19,6 +19,9 @@ const siteMetadata = {
   linkedin: '',
   locale: 'ko-KR',
   maxLikeCount: 4,
+  blog: {
+    postsPerScroll: 10,
+  },
   oauth: {
     providers: ['google', 'github', 'naver', 'kakao'],
   },

--- a/hooks/useInfiniteScrollObserver.ts
+++ b/hooks/useInfiniteScrollObserver.ts
@@ -1,0 +1,25 @@
+import { RefObject, useEffect } from 'react';
+
+interface Props {
+  target: RefObject<HTMLDivElement | null>;
+  onIntersect: (entry: IntersectionObserverEntry[]) => void;
+}
+
+const observerOption = {
+  threshold: 1,
+  rootMargin: '0px',
+};
+
+const useInfiniteScrollObserver = ({ target, onIntersect }: Props) => {
+  useEffect(() => {
+    let observer: IntersectionObserver;
+    if (target?.current) {
+      observer = new IntersectionObserver(onIntersect, observerOption);
+      observer.observe(target.current);
+    }
+
+    return () => observer && observer.disconnect();
+  }, [target, onIntersect]);
+};
+
+export default useInfiniteScrollObserver;

--- a/hooks/useIsFirstRender.ts
+++ b/hooks/useIsFirstRender.ts
@@ -1,0 +1,15 @@
+import { useRef } from 'react';
+
+function useIsFirstRender(): boolean {
+  const isFirst = useRef(true);
+
+  if (isFirst.current) {
+    isFirst.current = false;
+
+    return true;
+  }
+
+  return false;
+}
+
+export default useIsFirstRender;

--- a/layouts/ListLayout.tsx
+++ b/layouts/ListLayout.tsx
@@ -1,8 +1,13 @@
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
+import { filterBlogPosts } from '@/lib/contentlayer';
 import { PostListItem } from '@/lib/types';
+import useDebounce from '@/hooks/useDebounce';
+import useInfiniteScrollObserver from '@/hooks/useInfiniteScrollObserver';
+import useIsFirstRender from '@/hooks/useIsFirstRender';
 
 import phrases from '@/data/phrases';
+import siteMetadata from '@/data/siteMetadata';
 
 import PostList from '@/components/card-and-list/PostList';
 
@@ -13,15 +18,46 @@ interface Props {
 }
 
 export default function ListLayout({ posts, title, description }: Props) {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+  const isFirstRender = useIsFirstRender();
   const [searchValue, setSearchValue] = useState('');
-  const filteredBlogPosts = posts.filter((post: PostListItem) => {
-    const searchContent = post.title + post.summary + post.tags?.join(' ');
-    return searchContent.toLowerCase().includes(searchValue.toLowerCase());
-  });
+  const [displayPosts, setDisplayPosts] = useState<PostListItem[]>(
+    posts.slice(0, siteMetadata.blog.postsPerScroll)
+  );
 
-  // If initialDisplayPosts exist, display it if no searchValue is specified
-  const displayPosts =
-    posts.length > 0 && !searchValue ? posts : filteredBlogPosts;
+  const setNextDisplayPosts = (init = false) => {
+    setDisplayPosts((prev) => {
+      const _posts = filterBlogPosts(posts, searchValue);
+      const nextPosts = _posts.slice(
+        0,
+        (init ? 0 : prev.length) + siteMetadata.blog.postsPerScroll
+      );
+
+      if (nextPosts.length !== prev.length) return nextPosts;
+
+      let idx;
+      for (idx = 0; idx < nextPosts.length; idx++) {
+        if (nextPosts[idx] !== prev[idx]) break;
+      }
+      return idx === nextPosts.length ? prev : nextPosts;
+    });
+  };
+
+  useDebounce(() => !isFirstRender && setNextDisplayPosts(true), 300, [
+    searchValue,
+  ]);
+
+  const onIntersect = useCallback(
+    ([entry]: IntersectionObserverEntry[]) =>
+      entry.isIntersecting && setNextDisplayPosts(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [searchValue]
+  );
+
+  useInfiniteScrollObserver({
+    target: targetRef,
+    onIntersect: onIntersect,
+  });
 
   return (
     <>
@@ -56,6 +92,7 @@ export default function ListLayout({ posts, title, description }: Props) {
           </div>
         </div>
         <PostList posts={displayPosts} />
+        <div ref={targetRef} />
       </div>
     </>
   );

--- a/lib/contentlayer.ts
+++ b/lib/contentlayer.ts
@@ -1,5 +1,7 @@
 import type { Blog, DocumentTypes } from 'contentlayer/generated';
 
+import { PostListItem } from '@/lib/types';
+
 export function dateSortDesc(a: string, b: string, reverse: boolean) {
   if (a > b) return reverse ? 1 : -1;
   if (a < b) return reverse ? -1 : 1;
@@ -58,4 +60,12 @@ export function allCoreContent<T extends DocumentTypes>(contents: T[]) {
 
 export function pickBlogItem(blog: Blog) {
   return pick(blog, ['title', 'slug', 'date', 'tags', 'summary', 'images']);
+}
+
+export function filterBlogPosts(posts: PostListItem[], word: string) {
+  if (!word) return posts;
+  return posts.filter((post: PostListItem) => {
+    const searchContent = post.title + post.summary + post.tags?.join(' ');
+    return searchContent.toLowerCase().includes(word.toLowerCase());
+  });
 }


### PR DESCRIPTION
* Closes #226 

## ✨ 구현 기능 명세
/blog, /tags, /series 페이지와 같이 ListLayout을 사용하는 페이지에서 무한스크롤을 이용하여 포스트를 볼 수 있도록 변경합니다.

## 🎁 PR Point
`useInfiniteScrollObserver` 커스텀 훅을 이용하여 무한스크롤을 구현하였습니다. `useInfiniteScrollObserver`의 useEffect deps에 onIntersect가 있는 이유는 아래 기술하였습니다.

searchValue가 변경될 경우 debounce를 적용하여 displayPosts가 변경됩니다.

## 😭 어려웠던 점
`ListLayout`에 `searchValue` state가 있습니다. 그리고 이 state를 사용하는 `setNextDisplayPosts`라는 함수가 있고, 이 함수를 `onIntersect` 함수에서 호출하고 있습니다. 또, 이 onIntersect 함수를 `useInfiniteScrollObserver`에 넘겨주고 있습니다.

첫 구현에서 useInfiniteScrollObserver의 useEffect의 deps에 onIntersect가 없었습니다. 그래서 아무리 onIntersect가 호출되어도 searchValue가 변경되었음에도 불구하고 계속 빈 문자열이었습니다. 왜냐하면 맨 처음 useInfiniteScrollObserver가 호출되었을 때의 onIntersect 함수는 searchValue가 빈문자열인 상황으로 생성되어 초기화가 되어서, searchValue가 바뀌어도 useInfiniteScrollObserver 에서 onIntersect 함수를 호출하면 현재의 searchValue가 무엇이든지 간에 빈문자열인 searchValue 상태로 onIntersect가 수행되었던 것입니다.

이 원인을 파악하는 것이 어려웠습니다.

## ⏰ 실제 소요 시간
6h
