### PR TITLE
날짜 문구 변경 및 바로 보이지 않는 버그 해결

### DIFF
--- a/components/card-and-list/PostCard.tsx
+++ b/components/card-and-list/PostCard.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 
+import formattedDate from '@/lib/formattedDate';
 import { PostListItem } from '@/lib/types';
-import useFormattedDate from '@/hooks/useFormattedDate';
 
 import ViewCounter from '@/components/blog/ViewCounter';
 import ImageWithFallback from '@/components/Image/ImageWithFallback';
@@ -48,7 +48,7 @@ const PostCard = ({ post }: Props) => {
         <dl className="flex gap-2 text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
           <dt className="sr-only">작성 날짜</dt>
           <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
-            <time dateTime={date}>{useFormattedDate(date)}</time>
+            <time dateTime={date}>{formattedDate(date)}</time>
           </dd>
           <p className="bold">-</p>
           <dt className="sr-only">조회수</dt>

--- a/components/card-and-list/SeriesCard.tsx
+++ b/components/card-and-list/SeriesCard.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
 import { useState } from 'react';
 
+import formattedDate from '@/lib/formattedDate';
 import { SeriesListItem } from '@/lib/types';
-import useFormattedDate from '@/hooks/useFormattedDate';
 
 import phrases from '@/data/phrases';
 
@@ -42,7 +42,7 @@ const SeriesCard = ({ series }: Props) => {
             </span>
             <span className="weak-text"> · </span>
             <span className="weak-text">
-              {phrases.Series.lastUpdate} {useFormattedDate(lastmod)}
+              {phrases.Series.lastUpdate} {formattedDate(lastmod, false)}
             </span>
           </div>
         </div>

--- a/data/phrases.ts
+++ b/data/phrases.ts
@@ -14,6 +14,13 @@ const phrases = {
   cancel: '취소',
   toc: 'Table of contents',
   delete_successful: '성공적으로 삭제했습니다',
+  formattingDate: {
+    today: '오늘',
+    daysAgo: '일 전',
+    weeksAgo: '주 전',
+    monthsAgo: '개월 전',
+    yearsAgo: '년 전',
+  },
   Main: {
     name: 'Time Gambit',
     description: '호기심과 탐구심과 순수함을 잃지 않으려고 노력합니다.',

--- a/lib/formattedDate.ts
+++ b/lib/formattedDate.ts
@@ -1,0 +1,32 @@
+import phrases from '@/data/phrases';
+import siteMetadata from '@/data/siteMetadata';
+
+const OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+};
+
+const ONE_DAY_MILLISECONDS = 60 * 60 * 24 * 1000;
+
+const formattedDate = (date: string, absolute = true) => {
+  const createdAt = new Date(date);
+  if (absolute)
+    return createdAt.toLocaleDateString(siteMetadata.locale, OPTIONS);
+
+  createdAt.setHours(0, 0, 0, 0);
+  const ms = Number(new Date().setHours(0, 0, 0, 0)) - Number(createdAt);
+  if (ms === 0) return phrases.formattingDate.today; // today
+  const days = ms / ONE_DAY_MILLISECONDS;
+  if (days < 7) return `${Math.floor(days)}${phrases.formattingDate.daysAgo}`; // days ago
+  const weeks = days / 7;
+  if (weeks < 5)
+    return `${Math.floor(weeks)}${phrases.formattingDate.weeksAgo}`; // weeks ago
+  const months = days / 30;
+  if (months < 12)
+    return `${Math.floor(months)}${phrases.formattingDate.monthsAgo}`; // months ago
+  const years = days / 365;
+  return `${Math.floor(years)}${phrases.formattingDate.yearsAgo}`; // years ago
+};
+
+export default formattedDate;


### PR DESCRIPTION
* Closes #246 

## ✨ 구현 기능 명세
series의 날짜 문구를 오늘, n일 전, n주 전, n개월 전, n년 전으로 보이도록 개선합니다. 날짜가 바로 보이지 않던 버그를 해결합니다.

## 🎁 PR Point
커스텀훅인 useFormattedDate에서 단순 함수인 formattedDate 함수를 사용하도록 변경하였습니다. PostCard에 적용하지 않은 이유는 적용하였을 때 그닥 보기 좋지 않았기 때문입니다.

## ⏰ 실제 소요 시간
1h

## 🖥 스크린샷
![image](https://user-images.githubusercontent.com/32933980/208224475-49642579-4826-4ef6-9c9b-f09ad8f4c044.png)
