### PR TITLE
아이패드 Header 버그 해결

### DIFF
--- a/hooks/useScrollDirection.ts
+++ b/hooks/useScrollDirection.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 
 import throttle from '@/lib/throttle';
 
+const THRESHOLD = 30;
+const TOP_BOUND = 20;
 export const useScrollDirection = () => {
   const scrollYPos = useRef(0);
   const [scrollDirection, setScrollDirection] = useState('up');
@@ -9,7 +11,11 @@ export const useScrollDirection = () => {
   useEffect(() => {
     const handleScroll = () => {
       const newY = window.scrollY;
-      setScrollDirection(scrollYPos.current > newY ? 'up' : 'down');
+      if (newY < TOP_BOUND) {
+        setScrollDirection('up');
+      } else if (Math.abs(newY - scrollYPos.current) >= THRESHOLD) {
+        setScrollDirection(scrollYPos.current > newY ? 'up' : 'down');
+      }
       scrollYPos.current = window.scrollY;
     };
 


### PR DESCRIPTION
* Closes #247 

## ✨ 구현 기능 명세
아이패드에서 상단으로 당겼다가 놓을 경우, Header가 사라집니다. 이 버그를 해결합니다.

## 🎁 PR Point
TOP_BOUND를 두어 scrollY가 그 미만일 경우 항상 헤더를 보이게 바꾸었습니다. 또, THRESHOLD 미만으로 스크롤을 움직일 경우 scrollDirection이 바뀌도록 하였습니다.

## ⏰ 실제 소요 시간
20m
