### PR TITLE
Header 컴포넌트 버벅임 해결

### DIFF
--- a/components/TOC/SmallWidthTOC.tsx
+++ b/components/TOC/SmallWidthTOC.tsx
@@ -14,16 +14,16 @@ const SmallWidthTOC = () => {
       <button
         className={`fixed right-0 top-[59px] rounded-l-md border-y-2 border-l-2 border-primary-700 bg-primary-500 px-2 py-1 
         text-gray-100 duration-500 dark:border-primary-500 dark:bg-primary-700 dark:text-gray-200 sm:top-[50px]
-        ${scrollDirection === 'down' ? '-right-[50px]' : 'right-0'} 
+        ${scrollDirection === 'down' ? 'translate-x-[50px]' : 'traslate-x-0'} 
         `}
         onClick={() => setTocShow(true)}
       >
         TOC
       </button>
       <article
-        className={`fixed top-[59px] z-20 h-fit max-h-[85vh] w-80 overflow-y-scroll rounded-l-lg border-y-2 
+        className={`fixed top-[59px] right-0 z-20 h-fit max-h-[85vh] w-80 overflow-y-scroll rounded-l-lg border-y-2 
         border-l-2 border-primary-700 bg-white duration-500 scrollbar-hide dark:bg-gray-900 
-        sm:top-[50px] ${tocShow ? 'right-0' : '-right-80'}
+        sm:top-[50px] ${tocShow ? 'translate-x-0' : 'translate-x-80'}
         `}
       >
         <button
@@ -35,7 +35,7 @@ const SmallWidthTOC = () => {
             bg-primary-500 text-gray-100 dark:text-gray-200"
           />
         </button>
-        <div className="-mt-5 text-center text-2xl text-gray-300 duration-500 dark:text-gray-800">
+        <div className="-mt-5 text-center text-2xl text-gray-300 dark:text-gray-700">
           Table of Contents
         </div>
         <ul className="space-y-1.5 p-5 transition-colors">

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -18,7 +18,7 @@ export default function Header() {
   const isSamePath = (title: string) => path === title.toLowerCase();
 
   const navItems = (
-    <nav>
+    <nav className="hidden sm:block">
       <ul className="flex">
         {navLinks.map(({ href, title }, idx) => (
           <li
@@ -46,7 +46,9 @@ export default function Header() {
   return (
     <header
       className={`w-section fixed left-0 right-0 z-30 flex items-center justify-between border-b-2 bg-white py-2 transition-all duration-500 dark:bg-gray-900 ${
-        scrollDirection === 'down' ? '-top-[60px] sm:-top-14' : 'top-0'
+        scrollDirection === 'down'
+          ? '-translate-y-[60px] sm:-translate-y-14'
+          : 'translate-y-0'
       }`}
     >
       <Link
@@ -66,7 +68,7 @@ export default function Header() {
         )}
       </Link>
       <div className="flex items-center text-base leading-5">
-        <div className="hidden sm:block">{navItems}</div>
+        {navItems}
         <ThemeSwitch />
         <MobileNav />
       </div>

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -47,7 +47,7 @@ export default function Header() {
     <header
       className={`w-section fixed left-0 right-0 z-30 flex items-center justify-between border-b-2 bg-white py-2 transition-all duration-500 dark:bg-gray-900 ${
         scrollDirection === 'down'
-          ? '-translate-y-[60px] sm:-translate-y-14'
+          ? '-translate-y-[70px] sm:-translate-y-16'
           : 'translate-y-0'
       }`}
     >

--- a/components/common/MobileNav.tsx
+++ b/components/common/MobileNav.tsx
@@ -41,7 +41,7 @@ const MobileNav = () => {
         </svg>
       </button>
       <div
-        className={`fixed top-0 left-0 z-10 h-full w-full transform bg-gray-200 opacity-95 duration-300 ease-in-out dark:bg-gray-800 ${
+        className={`fixed top-0 left-0 z-10 h-screen w-full transform bg-gray-200 opacity-95 duration-300 ease-in-out dark:bg-gray-800 ${
           navShow ? 'translate-x-0' : 'translate-x-full'
         }`}
       >


### PR DESCRIPTION
* Closes #254 

## ✨ 구현 기능 명세
Header 컴포넌트가 나오고 사라질 때 버벅이는 버그를 해결합니다.

## 🎁 PR Point
기존의 top, right를 바꾸던 것에서 translate를 사용하도록 변경하였습니다. top, right는 Paint, Composite 단계를 거치는 Reflow, translate를 사용하면 Composite 단계만 거치는 Repaint를 수행합니다. 이를 통한 성능향상을 기대합니다. 

MobileNav 컴포넌트에서 h-full이 제대로 동작하지 않아 h-screen으로 수정하였습니다.

## 😭 어려웠던 점
원인파악이 힘들었습니다.

## ⏰ 실제 소요 시간
40m
