### PR TITLE
터치기기일 경우 tooltip 렌더링하지 않기

### DIFF
--- a/src/components/mdxComponents/FootnoteTooltip.tsx
+++ b/src/components/mdxComponents/FootnoteTooltip.tsx
@@ -21,7 +21,7 @@ const FootnoteTooltip = ({ idx, show }: Props) => {
   const ref = useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
-    if (!ref.current || window.innerWidth <= 640) return;
+    if (!ref.current) return;
     ref.current.style.visibility = show ? 'visible' : 'hidden';
   }, [show]);
 

--- a/src/components/mdxComponents/InlineFootnote.tsx
+++ b/src/components/mdxComponents/InlineFootnote.tsx
@@ -1,5 +1,7 @@
 import { AnchorHTMLAttributes, DetailedHTMLProps, useState } from 'react';
 
+import { isTouchDevice } from '@/lib/utils';
+
 import FootnoteTooltip from './FootnoteTooltip';
 
 const InlineFootnote = ({
@@ -22,7 +24,9 @@ const InlineFootnote = ({
         {...rest}
         className="py-2 before:content-['['] after:content-[']']"
       />
-      <FootnoteTooltip idx={rest.children as string} show={show} />
+      {!isTouchDevice() && (
+        <FootnoteTooltip idx={rest.children as string} show={show} />
+      )}
     </span>
   );
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,4 +6,9 @@ const sameAllElements = (a: unknown[], b: unknown[]) => {
   return a.every((item, idx) => item === b[idx]);
 };
 
-export { getImageWithFallback, sameAllElements };
+const isTouchDevice = () => {
+  if (typeof window === 'undefined') return false;
+  return 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+};
+
+export { getImageWithFallback, isTouchDevice, sameAllElements };


### PR DESCRIPTION
* Closes #308 

## ✨ 구현 기능 명세
터치기기일 경우 FootnoteTooltip을 렌더링하지 않습니다.

## 🎁 PR Point
PC에서 터치기기 상태로 시작할 경우, 상태를 해제하여도 여전히 `isTouchDevice()`는 true인 상태입니다. 반대로 터치기기가 아닌 상태로 시작할 경우, 상태를 터치기기로 변경하여도 `isTouchDevice()`는 여전히 false인 상태가 유지됩니다.

## 😭 어려웠던 점
PR Point 때문에 터치기기가 아닌 상태에서 터치기기 상태로 변경할 경우 렌더링이 이상하게 됩니다.

![image](https://user-images.githubusercontent.com/32933980/209818850-5fe5688d-33b7-44bb-9653-4b9fa7cf389f.png)

## ⏰ 실제 소요 시간
20m
