### PR TITLE
조회수에 시간기준 추가

### DIFF
--- a/data/siteMetadata.mjs
+++ b/data/siteMetadata.mjs
@@ -23,6 +23,8 @@ const siteMetadata = {
     maxLikeCount: 4,
     postsPerScroll: 10,
     homePostLength: 3,
+    // Viewing the same article within 4 hours does not increase view count.
+    viewCountTimeLimit: 4,
   },
   oauth: {
     providers: ['google', 'github', 'naver', 'kakao'],

--- a/src/components/blog/ViewCounter.tsx
+++ b/src/components/blog/ViewCounter.tsx
@@ -1,3 +1,4 @@
+import siteMetadata from 'data/siteMetadata.mjs';
 import { useEffect } from 'react';
 import { IoEyeOutline } from 'react-icons/io5';
 
@@ -9,15 +10,29 @@ interface Props {
   type?: 'POST' | 'GET';
 }
 
-const LAST_POST = 'lastPost';
+const LAST_POST = 'last-post';
+
+const LIMIT_TIME =
+  (siteMetadata.blogPost.viewCountTimeLimit || 0) * 60 * 60 * 1000;
 
 const ViewCounter = ({ slug, type = 'POST', shown = false }: Props) => {
   const { viewCount, isLoading, isError, increment } = usePostViews(slug);
 
   useEffect(() => {
-    if (type === 'GET' || localStorage.getItem(LAST_POST) === slug) return;
+    if (type === 'GET') return;
 
-    localStorage.setItem(LAST_POST, slug);
+    const { slug: storageSlug, date: storageDate } = JSON.parse(
+      localStorage.getItem(LAST_POST) || '{}'
+    );
+
+    if (
+      storageSlug === slug &&
+      storageDate &&
+      Number(new Date()) - Number(new Date(storageDate)) < LIMIT_TIME
+    )
+      return;
+
+    localStorage.setItem(LAST_POST, JSON.stringify({ slug, date: new Date() }));
 
     increment();
   }, [increment, slug, type]);


### PR DESCRIPTION
* Closes #309 

## ✨ 구현 기능 명세
조회수에 시간기준을 추가하였습니다.

## 🎁 PR Point
localstorage에 last-post을 키로하여 json 형태로 slug와 date를 저장합니다. 그리고 slug와 같고, 4시간 이내에 같은 포스트를 봤을 경우 조회수가 증가되지 않으며, 4시간 이후에 포스트를 봤을 경우 조회수가 증가됩니다.

## ⏰ 실제 소요 시간
20m
