### PR TITLE
MobileNav에 현재 페이지 하이라이트

### DIFF
--- a/src/components/common/Header/MobileNav.tsx
+++ b/src/components/common/Header/MobileNav.tsx
@@ -1,12 +1,18 @@
 import navLinks from 'data/navLinks';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 interface Props {
   navShow: boolean;
   onToggleNav: () => void;
 }
 
+const isCurPath = (path: string, title: string) =>
+  path.includes(title.toLowerCase());
+
 const MobileNav = ({ navShow, onToggleNav }: Props) => {
+  const router = useRouter();
+
   return (
     <div
       className={`fixed top-0 left-0 z-40 h-screen w-screen transform bg-gray-200 opacity-95 duration-300 ease-in-out dark:bg-gray-800 sm:hidden ${
@@ -36,15 +42,16 @@ const MobileNav = ({ navShow, onToggleNav }: Props) => {
       </div>
       <nav className="fixed mt-8 h-full">
         {navLinks.map((link) => (
-          <div key={link.title} className="px-12 py-4">
-            <Link
-              href={link.href}
-              className="text-2xl font-bold tracking-widest text-gray-900 dark:text-gray-100"
-              onClick={onToggleNav}
-            >
-              {link.title}
-            </Link>
-          </div>
+          <Link
+            key={link.title}
+            href={link.href}
+            className={`mx-12 my-8 block w-fit text-2xl font-bold tracking-widest text-gray-900 decoration-primary-600 decoration-4 underline-offset-8 dark:text-gray-100 dark:decoration-primary-400 ${
+              isCurPath(router.pathname, link.title) ? 'underline' : ''
+            }`}
+            onClick={onToggleNav}
+          >
+            {link.title}
+          </Link>
         ))}
       </nav>
     </div>


### PR DESCRIPTION
* Closes #332 

## ✨ 구현 기능 명세
MobileNav에 현재 페이지가 어디인지 알려주는 하이라이트 기능을 구현합니다.

## 🎁 PR Point
불필요한 div 태그를 제거하였습니다.

## 😭 어려웠던 점
MobileNav가 열려있을 때 뒤로가기와 앞으로가기를 했을 때 닫히도록 하려고 했습니다. 이 때문에 삽질을 많이 하였는데 현재는 불필요하다고 생각되어 추후에 필요할 경우 구현하도록 하겠습니다.

## ⏰ 실제 소요 시간
1h

## 🖥 스크린샷
![image](https://user-images.githubusercontent.com/32933980/210192576-f6f4babd-0990-4174-a316-996a77fc2a93.png)
