### PR TITLE
홈 페이지 용량 및 인기 포스트 갱신

### DIFF
--- a/data/siteMetadata.mjs
+++ b/data/siteMetadata.mjs
@@ -26,6 +26,8 @@ const siteMetadata = {
     homePopularPostLength: 3,
     // Viewing the same article within 4 hours does not increase view count.
     viewCountTimeLimit: 4,
+    // popular post list renewal period (seconds)
+    renewalPeriod: 10,
   },
   oauth: {
     providers: ['google', 'github', 'naver', 'kakao'],

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -42,11 +42,13 @@ export const getStaticProps: GetStaticProps = async () => {
     });
     popularPosts = allBlogs
       .filter((post) => post.slug in slug2Order)
-      .sort((a, b) => slug2Order[a.slug] - slug2Order[b.slug]);
+      .sort((a, b) => slug2Order[a.slug] - slug2Order[b.slug])
+      .map(pickBlogItem);
   }
 
   return {
     props: { recentPosts, popularPosts },
+    revalidate: siteMetadata.blogPost.renewalPeriod,
   };
 };
 


### PR DESCRIPTION
* Closes #373
* Closes #374 

## ✨ 구현 기능 명세
홈 페이지의 용량을 줄였습니다. 인기 포스트가 주기적으로 갱신되도록 하였습니다.

## 🎁 PR Point
Next JS의 getStaticProps의 `revalidate`를 이용해 10초마다 갱신되도록 하였습니다.

## ⏰ 실제 소요 시간
10m
