### PR TITLE
댓글 lazy loading 구현

### DIFF
--- a/data/siteMetadata.mjs
+++ b/data/siteMetadata.mjs
@@ -41,6 +41,7 @@ const siteMetadata = {
   },
   comment: {
     provider: 'giscus', // supported providers: giscus, utterances, disqus
+    lazyLoad: true, // when true, comment will be loaded when user scrolls to comment box
     giscusConfig: {
       // Visit the link below, and follow the steps in the 'configuration' section
       // https://giscus.app/

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -34,18 +34,16 @@ export default function App({
       defaultTheme={siteMetadata.theme}
       enableColorScheme={false}
     >
-      <>
-        <Head>
-          <meta content="width=device-width, initial-scale=1" name="viewport" />
-        </Head>
-        <Analytics />
-        <LayoutWrapper className={`${dejavu.variable} font-sans`}>
-          <SessionProvider session={session}>
-            <Component {...pageProps} />
-          </SessionProvider>
-        </LayoutWrapper>
-        <ToastContainer />
-      </>
+      <Head>
+        <meta content="width=device-width, initial-scale=1" name="viewport" />
+      </Head>
+      <Analytics />
+      <LayoutWrapper className={`${dejavu.variable} font-sans`}>
+        <SessionProvider session={session}>
+          <Component {...pageProps} />
+        </SessionProvider>
+      </LayoutWrapper>
+      <ToastContainer />
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
* Closes #400 

## ✨ 구현 기능 명세

댓글의 lazy loading을 구현하였습니다.

## 🎁 PR Point

### lazy loading 여부 선택
`siteMetadata` 에 `comment.lazyLoad` 의 boolean 값을 이용해 lazyLoading 여부를 선택할 수 있도록 구현하였습니다.

### IntersectionObserver를 이용한 lazy loading 구현
```ts
  // Reload on theme change
  useEffect(() => {
    let observer: IntersectionObserver;
    const iframe = document.querySelector('iframe.giscus-frame');
    // when comments are loaded
    if (iframe) {
      LoadComments();
    }
    // when comments are not loaded and button is visible
    else if (siteMetadata.comment.lazyLoad && buttonRef.current) {
      observer = new IntersectionObserver(([entry]) => {
        entry.isIntersecting && LoadComments();
      }, observerOption);
      observer.observe(buttonRef.current);
    }

    return () => observer && observer.disconnect();
  }, [buttonRef, LoadComments]);
```

`useEffect` 내부에서 이미 댓글이 불러와졌었다면 `LoadComments()`가 실행되고, 아직 불려온 상태가 아니라면 `IntersectionObserver`를 붙여주도록 구현하였습니다.

## ⏰ 실제 소요 시간
20m

## 🖥 스크린샷
![lazy](https://user-images.githubusercontent.com/32933980/228212750-5f747033-6125-45d6-9487-e951fe78d105.gif)

