### PR TITLE
댓글창 intersectionObserver 옵션 수정

### DIFF
--- a/src/components/comments/Giscus.tsx
+++ b/src/components/comments/Giscus.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 const observerOption = {
   threshold: 1,
-  rootMargin: '500px 0px',
+  rootMargin: '0px 0px 600px',
 };
 
 const Giscus = () => {


### PR DESCRIPTION
## ✨ 구현 기능 명세
댓글창의 intersectionObserver 옵션을 수정하였습니다.

## 🎁 PR Point

```ts
const observerOption = {
  threshold: 1,
  // rootMargin: '500px 0',   변경전
  rootMargin: '0px 0px 600px',
};
```
rootMargin을 하단에만 600px을 주도록 변경하였습니다.

## ⏰ 실제 소요 시간
5m
