### PR TITLE
Footnote 기능 보완

### DIFF
--- a/data/phrases.ts
+++ b/data/phrases.ts
@@ -13,7 +13,7 @@ const phrases = {
   delete: '삭제',
   cancel: '취소',
   toc: 'Table of contents',
-  delete_successful: '성공적으로 삭제했습니다',
+  close: '닫기',
   formattingDate: {
     today: '오늘',
     daysAgo: '일 전',

--- a/src/components/mdxComponents/FootnoteModal.tsx
+++ b/src/components/mdxComponents/FootnoteModal.tsx
@@ -1,0 +1,50 @@
+import phrases from 'data/phrases';
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+
+import useGetFootnoteBody from '@/hooks/useGetFootnoteBody';
+
+interface Props {
+  onClose: () => void;
+  idx: string;
+}
+
+const FootnoteModal = ({ onClose, idx }: Props) => {
+  const element =
+    typeof window !== 'undefined' && document.querySelector('#modal');
+
+  const body = useGetFootnoteBody(idx);
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, []);
+
+  return element && body
+    ? createPortal(
+        <div
+          className="fixed top-0 left-0 z-50 h-screen w-screen bg-black bg-opacity-40"
+          onClick={onClose}
+        >
+          <div className="flex w-full translate-y-[15vh] flex-col">
+            <div
+              className="prose inline-block max-h-[70vh] w-full overflow-y-auto whitespace-normal rounded-t-sm bg-white px-3 py-4 scrollbar-hide dark:prose-dark dark:bg-gray-800"
+              onClick={(e) => e.stopPropagation()}
+              dangerouslySetInnerHTML={{ __html: body as string }}
+            />
+            <button
+              onClick={onClose}
+              className="w-full rounded-b-sm border-t border-t-gray-200 bg-gray-100 py-2 text-sm dark:border-t-gray-900 dark:bg-gray-700 dark:text-gray-200"
+            >
+              {phrases.close}
+            </button>
+          </div>
+        </div>,
+        element
+      )
+    : null;
+};
+
+export default FootnoteModal;

--- a/src/components/mdxComponents/FootnoteTooltip.tsx
+++ b/src/components/mdxComponents/FootnoteTooltip.tsx
@@ -1,4 +1,6 @@
-import { CSSProperties, useEffect, useRef, useState } from 'react';
+import { CSSProperties, useEffect, useRef } from 'react';
+
+import useGetFootnoteBody from '@/hooks/useGetFootnoteBody';
 
 interface Props {
   idx: string;
@@ -9,15 +11,8 @@ const OFFSET_BOUNDARY = 200;
 const Y_OFFSET = 20;
 const X_OFFSET = 20;
 
-const removeBackTag = (innerHtml: string) => {
-  return innerHtml.replace(
-    /<a href="#user-content-fnref-[0-9a-zA-Z%]+" aria-label="Back to content".*>↩<\/a>/g,
-    ''
-  );
-};
-
 const FootnoteTooltip = ({ idx, show }: Props) => {
-  const [body, setBody] = useState('');
+  const body = useGetFootnoteBody(idx);
   const ref = useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
@@ -47,14 +42,6 @@ const FootnoteTooltip = ({ idx, show }: Props) => {
 
     return ret;
   };
-
-  useEffect(() => {
-    const footnotes = document.querySelector(
-      `.footnotes ol>li:nth-child(${idx})`
-    );
-    setBody(removeBackTag(footnotes?.innerHTML ?? ''));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return body ? (
     <span

--- a/src/components/mdxComponents/FootnoteTooltip.tsx
+++ b/src/components/mdxComponents/FootnoteTooltip.tsx
@@ -7,8 +7,7 @@ interface Props {
   show: boolean;
 }
 
-const OFFSET_BOUNDARY = 200;
-const Y_OFFSET = 20;
+const Y_OFFSET = 30;
 const X_OFFSET = 20;
 
 const FootnoteTooltip = ({ idx, show }: Props) => {
@@ -25,20 +24,30 @@ const FootnoteTooltip = ({ idx, show }: Props) => {
       return { transform: 'translateX(-50%)', top: Y_OFFSET };
     }
     const ret: CSSProperties = {};
-    const viewWidth = window.innerWidth;
-    const width = ref.current.offsetWidth;
+
     const { left, top } = ref.current.parentElement.getBoundingClientRect() || {
       left: 0,
       top: 0,
     };
+
+    // x-axix
+    const viewWidth = window.innerWidth;
+    const width = ref.current.offsetWidth;
     let translateX = -width / 2;
     if (left - width / 2 < 0) {
       translateX += width / 2 - left + X_OFFSET;
     } else if (left + width / 2 > viewWidth) {
       translateX -= left + width / 2 - viewWidth + X_OFFSET;
     }
-    ret.transform = `translateX(${translateX}px)`;
-    ret[top > OFFSET_BOUNDARY ? 'bottom' : 'top'] = Y_OFFSET;
+
+    // y-axis
+    const height = ref.current.offsetHeight;
+    let translateY = -height;
+    if (top - height - Y_OFFSET < 0) {
+      translateY += height + Y_OFFSET;
+    }
+
+    ret.transform = `translate(${translateX}px, ${translateY}px)`;
 
     return ret;
   };

--- a/src/components/mdxComponents/InlineFootnote.tsx
+++ b/src/components/mdxComponents/InlineFootnote.tsx
@@ -1,6 +1,9 @@
 import { AnchorHTMLAttributes, DetailedHTMLProps, useState } from 'react';
 
 import { isTouchDevice } from '@/lib/utils';
+import useIsClient from '@/hooks/useIsClient';
+
+import FootnoteModal from '@/components/mdxComponents/FootnoteModal';
 
 import FootnoteTooltip from './FootnoteTooltip';
 
@@ -12,23 +15,40 @@ const InlineFootnote = ({
   HTMLAnchorElement
 >) => {
   const [show, setShow] = useState(false);
+  const isClient = useIsClient();
 
-  return (
-    <span
-      className="group"
-      onMouseEnter={() => setShow(true)}
-      onMouseLeave={() => setShow(false)}
-    >
-      <a
-        href={href}
-        {...rest}
-        className="py-2 before:content-['['] after:content-[']']"
-      />
-      {!isTouchDevice() && (
+  if (isTouchDevice() && isClient) {
+    return (
+      <>
+        <span
+          {...rest}
+          className="py-2 text-primary-500 before:content-['['] after:content-[']'] dark:text-primary-400"
+          onClick={() => setShow(true)}
+        />
+        {show && (
+          <FootnoteModal
+            idx={rest.children as string}
+            onClose={() => setShow(false)}
+          />
+        )}
+      </>
+    );
+  } else {
+    return (
+      <span
+        className="group"
+        onMouseEnter={() => setShow(true)}
+        onMouseLeave={() => setShow(false)}
+      >
+        <a
+          href={href}
+          {...rest}
+          className="py-2 before:content-['['] after:content-[']']"
+        />
         <FootnoteTooltip idx={rest.children as string} show={show} />
-      )}
-    </span>
-  );
+      </span>
+    );
+  }
 };
 
 export default InlineFootnote;

--- a/src/hooks/useGetFootnoteBody.ts
+++ b/src/hooks/useGetFootnoteBody.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+const removeBackTag = (innerHtml: string) => {
+  return innerHtml.replace(
+    /<a href="#user-content-fnref-[0-9a-zA-Z%]+" aria-label="Back to content".*>↩<\/a>/g,
+    ''
+  );
+};
+
+const useGetFootnoteBody = (idx: string) => {
+  const [body, setBody] = useState('');
+
+  useEffect(() => {
+    const footnotes = document.querySelector(
+      `.footnotes ol>li:nth-child(${idx})`
+    );
+    setBody(removeBackTag(footnotes?.innerHTML ?? ''));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return body;
+};
+
+export default useGetFootnoteBody;

--- a/src/hooks/useIsClient.ts
+++ b/src/hooks/useIsClient.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+
+const useIsClient = () => {
+  const [isClient, setClient] = useState(false);
+
+  useEffect(() => {
+    setClient(true);
+  }, []);
+
+  return isClient;
+};
+
+export default useIsClient;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -38,6 +38,7 @@ class MyDocument extends Document {
         </Head>
         <body className="overflow-x-hidden antialiased">
           <Main />
+          <div id="modal" />
           <NextScript />
         </body>
       </Html>


### PR DESCRIPTION
* Closes #432 

## ✨ 구현 기능 명세

모바일 환경에서는 InlineFootnote 클릭시 모달창을 띄우도록 구현하였습니다.

데스크탑 환경에서 FootnoteTooltip를 위쪽으로 띄울 경우 스크린 범위를 벗어나면 아래쪽으로 띄우도록 변경하였습니다. 그리고 top, bottom 속성이 아닌 transform 속성을 이용하도록 변경하였습니다.

## 🎁 PR Point

### FootnoteModal

`createPortal`을 이용하여 모달창을 구현하였습니다. 블로그 내 모달창이 이 컴포넌트뿐이어서 portal 없이 구현하려고 했습니다. 그런데 p 태그 내(본문 내)에 div 태그(모달창)는 존재할 수 없기 때문에 에러가 발생하였습니다.

이를 해결하기 위해 `createPortal`을 이용하여 모달창을 구현하였습니다.

### FootnoteTooltip

```ts
    const height = ref.current.offsetHeight;
    let translateY = -height;
    if (top - height - Y_OFFSET < 0) {
      translateY += height + Y_OFFSET;
    }

    ret.transform = `translate(${translateX}px, ${translateY}px)`;
```

위와 같은 로직으로 tooltip의 y축 위치를 지정해주었습니다. 간단히 로직을 설명하자면 위쪽으로 띄웠을 경우 스크린을 벗어나면, 아래쪽으로 띄울 수 있도록 `translateY`를 조정해줍니다.

## ⏰ 실제 소요 시간
2h 30m

## 🖥 스크린샷

### 모바일
![image](https://user-images.githubusercontent.com/32933980/236392708-89a8e409-0a99-43d4-ad32-0b2ecb31b7d3.png)

### 데스크탑
![image](https://user-images.githubusercontent.com/32933980/236392786-5662f6f2-69d4-42e8-97c1-eecdaf4eb4c4.png)
