### PR TITLE
주석 모달창 애니메이션 적용

### DIFF
--- a/src/components/mdxComponents/FootnoteModal.tsx
+++ b/src/components/mdxComponents/FootnoteModal.tsx
@@ -1,5 +1,5 @@
 import phrases from 'data/phrases';
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import useGetFootnoteBody from '@/hooks/useGetFootnoteBody';
@@ -12,21 +12,32 @@ interface Props {
 const FootnoteModal = ({ onClose, idx }: Props) => {
   const element =
     typeof window !== 'undefined' && document.querySelector('#modal');
-
+  const [opened, setOpened] = useState(true);
   const body = useGetFootnoteBody(idx);
+  const timeout = useRef<ReturnType<typeof setTimeout>>();
+  const closeModal = () => {
+    setOpened(false);
+    timeout.current && clearTimeout(timeout.current);
+    timeout.current = setTimeout(() => {
+      onClose();
+    }, 100);
+  };
 
   useEffect(() => {
     document.body.style.overflow = 'hidden';
     return () => {
       document.body.style.overflow = 'unset';
+      timeout.current && clearTimeout(timeout.current);
     };
   }, []);
 
   return element && body
     ? createPortal(
         <div
-          className="fixed top-0 left-0 z-50 h-screen w-screen bg-black bg-opacity-40"
-          onClick={onClose}
+          className={`animate-modal fixed top-0 left-0 z-50 h-screen w-screen bg-black bg-opacity-40 ${
+            opened ? 'animate-modal-open' : 'animate-modal-close'
+          }`}
+          onClick={closeModal}
         >
           <div className="flex w-full translate-y-[15vh] flex-col">
             <div
@@ -35,7 +46,7 @@ const FootnoteModal = ({ onClose, idx }: Props) => {
               dangerouslySetInnerHTML={{ __html: body as string }}
             />
             <button
-              onClick={onClose}
+              onClick={closeModal}
               className="w-full rounded-b-sm border-t border-t-gray-200 bg-gray-100 py-2 text-sm dark:border-t-gray-900 dark:bg-gray-700 dark:text-gray-200"
             >
               {phrases.close}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -61,14 +61,24 @@ module.exports = {
           '0%': { left: '-100%' },
           '100%': { left: '150%' },
         },
+        modalOpenAnimation: {
+          '0%': { opacity: 0 },
+          '100%': { opacity: 1 },
+        },
+        modalCloseAnimation: {
+          '0%': { opacity: 1 },
+          '100%': { opacity: 0 },
+        },
       },
       animation: {
-        'bounce-left': 'bounceLeft 0.5s ease-in-out',
-        'bounce-right': 'bounceRight 0.5s ease-in-out',
+        'bounce-left': 'bounceLeft 500ms ease-in-out',
+        'bounce-right': 'bounceRight 500ms ease-in-out',
         emoji: 'postLikeEmojiAnimation 1s ease-in-out forwards',
         heart: 'postLikeHeartAnimation 1s ease-in-out',
         card: 'cardLoadedAnimation 500ms ease-in-out',
         loading: 'loadingAnimation 1.5s infinite',
+        'modal-open': 'modalOpenAnimation 150ms ease-in-out forwards',
+        'modal-close': 'modalCloseAnimation 100ms ease-in-out forwards',
       },
       typography: (theme) => ({
         DEFAULT: {


### PR DESCRIPTION
* Closes #432 

## ✨ 구현 기능 명세

주석 modal에 애니메이션을 적용하였습니다.

## 🎁 PR Point

### setTimeout 이용

```ts
  const timeout = useRef<ReturnType<typeof setTimeout>>();

  const closeModal = () => {
    setOpened(false);
    timeout.current && clearTimeout(timeout.current);
    timeout.current = setTimeout(() => {
      onClose();
    }, 100);
  };

  useEffect(() => {
    return () => {
      timeout.current && clearTimeout(timeout.current);
    };
  }, []);
```

닫을 때도 애니메이션을 적용하기 위해서 위와 같이 setTimeout 을 이용하여 애니메이션을 적용하였습니다. 모달창이 닫힐 때 clearTimeout을 해주기 위해 `useRef`로 `timeout` 변수를 관리해줍니다.

## ⏰ 실제 소요 시간
20m

## 🖥 스크린샷

![modal](https://user-images.githubusercontent.com/32933980/236401548-17536cca-d47f-4ee1-a02f-ffbba04ef5e6.gif)

