### PR TITLE
아이패드에서의 모달창 너비 문제 해결

### DIFF
--- a/src/components/mdxComponents/FootnoteModal.tsx
+++ b/src/components/mdxComponents/FootnoteModal.tsx
@@ -39,9 +39,9 @@ const FootnoteModal = ({ onClose, idx }: Props) => {
           }`}
           onClick={closeModal}
         >
-          <div className="flex w-full translate-y-[15vh] flex-col">
+          <div className="mx-auto flex max-w-3xl translate-y-[15vh] flex-col xl:max-w-5xl">
             <div
-              className="prose inline-block max-h-[70vh] w-full overflow-y-auto whitespace-normal rounded-t-sm bg-white px-3 py-4 scrollbar-hide dark:prose-dark dark:bg-gray-800"
+              className="prose max-h-[70vh] w-full max-w-none overflow-y-auto whitespace-normal rounded-t-sm bg-white px-3 py-4 scrollbar-hide dark:prose-dark dark:bg-gray-800"
               onClick={(e) => e.stopPropagation()}
               dangerouslySetInnerHTML={{ __html: body as string }}
             />


### PR DESCRIPTION
* Closes #444 

## ✨ 구현 기능 명세

아이패드에서 모달창 너비가 잘못된 문제가 있었습니다. 이 문제를 해결하였습니다.

## 🎁 PR Point

### 원인 및 해결방법

원인은 tailwind의 `prose` 속성 때문이었습니다. 이 속성으로 인해 너비가 자동으로 지정되었던 것입니다. [공식문서](https://tailwindcss.com/docs/typography-plugin#overriding-max-width)를 참고하여 `max-w-none` 속성을 추가하여 해결하였습니다.

## ⏰ 실제 소요 시간
20m

## 🖥 스크린샷
![image](https://user-images.githubusercontent.com/32933980/236585670-b0aecbaa-1d5d-409a-a5e6-f027d59baada.png)
