### PR TITLE
포스트 내 이미지 컴포넌트 priority 제거

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,7 +16,6 @@ const nextConfig = withContentlayer(
     reactStrictMode: true,
     swcMinify: true,
     experimental: {
-      appDir: true,
       serverComponentsExternalPackages: ['mysql2'],
     },
 

--- a/src/app/layout.client.tsx
+++ b/src/app/layout.client.tsx
@@ -6,11 +6,11 @@ import siteMetadata from 'data/site-metadata.mjs';
 
 import { ThemeProvider } from '@wits/next-themes';
 import { ToastContainer } from 'react-toastify';
-import Header from 'src/components/common/header';
 
 import { useRestoreScroll } from '@/hooks/use-restore-scroll';
 
 import Footer from '@/components/common/footer';
+import Header from '@/components/common/header';
 
 interface Props {
   children: ReactNode;
@@ -21,13 +21,11 @@ const BodyLayout = ({ children, className }: Props) => {
   return (
     <>
       <div className="fixed left-0 top-0 -z-10 h-screen w-screen bg-white transition-colors duration-300 dark:bg-gray-900" />
-      <div className="w-section">
-        <div className="flex h-screen flex-col justify-between">
-          <Header />
-          <main className={`mb-auto mt-24 ${className}`}>{children}</main>
-          <hr />
-          <Footer />
-        </div>
+      <div className="w-section flex flex-col justify-between">
+        <Header />
+        <main className={`mb-auto mt-24 ${className}`}>{children}</main>
+        <hr />
+        <Footer />
       </div>
     </>
   );

--- a/src/components/blog/scroll-indicator.tsx
+++ b/src/components/blog/scroll-indicator.tsx
@@ -2,23 +2,28 @@
 
 import { useEffect, useState } from 'react';
 
+import { IMAGE_LOAD } from '@/lib/image-load';
+
 const ScrollIndicator = () => {
   const [pageHeight, setPageHeight] = useState(1000000);
   const [scrollY, setScrollY] = useState(0);
   useEffect(() => {
     const onResize = () => {
-      setPageHeight(document.body.scrollHeight - document.body.clientHeight);
+      setPageHeight(document.body.scrollHeight - window.innerHeight);
     };
     const onScroll = () => {
       setScrollY(window.scrollY);
     };
+
     const timeout = setTimeout(() => onResize(), 1000);
     onScroll();
     window.addEventListener('scroll', onScroll);
     window.addEventListener('resize', onResize);
+    window.addEventListener(IMAGE_LOAD, onResize);
     return () => {
       window.removeEventListener('scroll', onScroll);
       window.removeEventListener('resize', onResize);
+      window.removeEventListener(IMAGE_LOAD, onResize);
       clearTimeout(timeout);
     };
   }, []);

--- a/src/components/image/zoom.tsx
+++ b/src/components/image/zoom.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState } from 'react';
 import NextImage, { ImageProps } from 'next/image';
 
+import { onCompleteImageLoad } from '@/lib/image-load';
+
 const DURATION = 300;
 const TIMEOUT_DELAY = 100;
 const BACKGROUND_OPACITY = 0.9;
@@ -82,6 +84,7 @@ const Zoom = (props: ImageProps) => {
         ref={imageRef}
         onClick={handleImageZoom}
         onError={() => setError(true)}
+        onLoadingComplete={onCompleteImageLoad}
         {...imageProps}
       />
     </>

--- a/src/components/mdx-components/custom-media.tsx
+++ b/src/components/mdx-components/custom-media.tsx
@@ -25,6 +25,7 @@ const FallbackImage = ({ alt }: { alt: string }) => (
 
 const CustomMedia = ({ src, alt }: Props) => {
   const [src1, src2] = src?.split(',') || [];
+
   return (
     <figure className="my-12">
       {isVideo(src) ? (
@@ -40,7 +41,6 @@ const CustomMedia = ({ src, alt }: Props) => {
         <ErrorBoundary fallback={<FallbackImage alt={alt as string} />}>
           <Zoom
             className={`mx-auto w-auto max-w-full${src2 ? ' dark:hidden' : ''}`}
-            priority={true}
             src={src1 as string}
             alt={alt as string}
             width="1000"
@@ -49,7 +49,6 @@ const CustomMedia = ({ src, alt }: Props) => {
           {src2 && (
             <Zoom
               className="absolute top-0 mx-auto hidden w-auto max-w-full dark:block"
-              priority={true}
               src={src2 as string}
               alt={alt as string}
               width="1000"

--- a/src/lib/image-load.ts
+++ b/src/lib/image-load.ts
@@ -1,0 +1,6 @@
+export const IMAGE_LOAD = 'image-load';
+
+export const onCompleteImageLoad = () => {
+  const event = new CustomEvent(IMAGE_LOAD);
+  dispatchEvent(event);
+};


### PR DESCRIPTION
* Closes #460 

## ✨ 구현 기능 명세

포스트 내 이미지들이 ScrollIndicator 때문에 priority true 였습니다. 이를 제거하고 커스텀 이벤트를 활용하여 ScrollIndicator가 올바르게 동작하도록 수정하였습니다.

## 🎁 PR Point

Zoom 컴포넌트가 포스트 내에서 사용되는 이미지 컴포넌트입니다. 이 컴포넌트 내에서 직접적으로 커스텀 이벤트 dispatch 함수를 import 하여 onLoadingComplete에 등록해주었습니다.

## ⏰ 실제 소요 시간
20m

## 🖥 스크린샷

![priority-false](https://github.com/jintak0401/timegambit-blog/assets/32933980/b71986d0-2b9d-4bc5-b5e9-e2ea1f7cd789)

